### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,22 +49,22 @@ A [full list of all the repos](https://github.com/NuGet) is available as well.
 
 ## How to build NuGet VisualStudio extension
 
-###Prerequisites:
+### Prerequisites:
 - [VisualStudio 2015](https://www.visualstudio.com/)
 - [VisualStudio 2015 SDK](https://msdn.microsoft.com/en-us/library/bb166441.aspx)
 - [Windows 10 SDK](https://dev.windows.com/en-US/downloads/windows-10-sdk)
 - Git 
 - Powershell
 
-###Steps to build the clients tools repo:
+### Steps to build the clients tools repo:
 - Clone [NuGet.Client](https://github.com/nuget/nuget.client) Repo by running the following command `git clone https://github.com/NuGet/NuGet.Client`
 - Start powershell
 - CD into the clone repo directory
 - Run `.\build.ps1 -CleanCache`
 
-######In case you have build issues please clean the local repo using `git clean -xdf` and retry building
+###### In case you have build issues please clean the local repo using `git clean -xdf` and retry building
 
-####Notable .\build.ps1 switches
+#### Notable .\build.ps1 switches
 - `-SkipVS14` - skips building binaries targeting Visual Studio "14" (released as Visual Studio 2015)
 - `-SkipVS15` - skips building binaries targeting Visual Studio "15"
 
@@ -77,7 +77,7 @@ Note that if only one of Visual Studio 2015 (Dev14) or Visual Studio 15 (Dev15) 
 - `-SkipILMerge` - builds without creating an ILMerged nuget.exe
 - `-Fast` - skips tests, submodule updates, and ILMerged nuget.exe
 
-###Build Artifacts
+### Build Artifacts
 - (RepoRootFolder)\Artifacts - this folder will contain the Vsix and NuGet command-line
 - (RepoRootFolder)\Nupkgs - this folder will contain all our projects packages
 

--- a/resources/AccountDeletionWorkflow/readme.md
+++ b/resources/AccountDeletionWorkflow/readme.md
@@ -1,1 +1,1 @@
-#Placeholder for feature UI mockup
+# Placeholder for feature UI mockup


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
