### PR TITLE
Add a design spec template that the NuGet team uses

### DIFF
--- a/designs/SPEC_TEMPLATE.md
+++ b/designs/SPEC_TEMPLATE.md
@@ -4,7 +4,6 @@
 * Status: In Review / Reviewed / Implementing / Implemented
 * Author(s): [NuGet](https://github.com/NuGet)
 * Issue: [1](https://github.com/NuGet/Home/issues/1) Issue Title
-* Type: Feature
 
 ## Problem Background
 

--- a/designs/SPEC_TEMPLATE.md
+++ b/designs/SPEC_TEMPLATE.md
@@ -2,21 +2,17 @@
 # Spec Name
 
 * Status: In Review / Reviewed / Implementing / Implemented
-* Author(s): [NuGet](https://github.com/NuGet)
+* Author(s): [Author Name](https://github.com/NuGet)
 * Issue: [1](https://github.com/NuGet/Home/issues/1) Issue Title
 
 ## Problem Background
 
 Present the background and the motivation for this design. 
-Present evidence why this is an important problem to tackle
+Present evidence why this is an important problem to tackle.
 
 ## Who are the customers
 
 Customers affected by this change.
-
-## Requirements
-
-Clarify the requirements in a few bullet points
 
 ## Goals
 

--- a/designs/SPEC_TEMPLATE.md
+++ b/designs/SPEC_TEMPLATE.md
@@ -1,0 +1,49 @@
+
+# Spec Name
+
+* Status: In Review / Reviewed / Implementing / Implemented
+* Author(s): [NuGet](https://github.com/NuGet)
+* Issue: [1](https://github.com/NuGet/Home/issues/1) Issue Title
+* Type: Feature
+
+## Problem Background
+
+Present the background and the motivation for this design. 
+Present evidence why this is an important problem to tackle
+
+## Who are the customers
+
+Customers affected by this change.
+
+## Requirements
+
+Clarify the requirements in a few bullet points
+
+## Goals
+
+Specifically call out the goals for this proposed design.
+
+## Non-Goals
+
+Call out things that are not in consideration for this design. 
+
+## Solution
+
+Describe the proposed solution in as much detail as you deem necessary.
+
+## Future Work
+
+Declare any future work if applicable.
+
+## Open Questions
+
+Any open questions not specifically called out in the design.
+
+## Considerations
+
+Any other solutions or approaches considered? 
+The rejected designs are often just as important as the proposed ones!
+
+### References
+
+References to related issues, features


### PR DESCRIPTION
Fixes https://github.com/NuGet/Client.Engineering/issues/154

This is basically a summary of the spec we have been using. 

Only change I've made is making all the `Open Questions`, `Considerations` etc. a heading 2. 

Once merged I will update any links in the wiki and one notes I can find talking about a spec template :) 

@skofman1 @xavierdecoster @joelverhagen @agr @shishirx34 @ryuyu @dannyjdev @loic-sharma @zhhyu  
Thoughts/comments welcome. Figured you have your own template, maybe we can unify to using one. 