### PR TITLE
Update NuGet Readme to include expanded Contribution & Feedback sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The NuGet Blog is where we announce new features, write engineering blog posts, 
 There are many ways in which you can participate in the project, for example:
 
 * [Submit bugs and feature requests, and help us verify as they are checked in](https://github.com/NuGet/Home/wiki/Submitting-Bugs-and-Suggestions)
-* [Review source code changes](https://github.com/NuGet/Home/pulls)
+* [Review NuGet proposals](https://github.com/NuGet/Home/pulls)
 * [Review the documentation and make pull requests for anything from typos to new content](https://github.com/NuGet/docs.microsoft.com-nuget)
 
 If you are interested in fixing issues and contributing directly to the code base, please see the document [Contribute To NuGet](https://github.com/NuGet/Home/wiki/Contribute-to-NuGet), which covers the following:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@ The NuGet Docs are the ideal place to start if you are new to NuGet. They are ca
 
 The NuGet Blog is where we announce new features, write engineering blog posts, demonstrate proof-of-concepts and features under development.
 
+## Contributing
+
+There are many ways in which you can participate in the project, for example:
+
+* [Submit bugs and feature requests, and help us verify as they are checked in](https://github.com/NuGet/Home/wiki/Submitting-Bugs-and-Suggestions)
+* [Review source code changes](https://github.com/NuGet/Home/pulls)
+* [Review the documentation and make pull requests for anything from typos to new content](https://github.com/NuGet/docs.microsoft.com-nuget)
+
+If you are interested in fixing issues and contributing directly to the code base, please see the document [Contribute To NuGet](https://github.com/NuGet/Home/wiki/Contribute-to-NuGet), which covers the following:
+
+* How to build and run from source
+* The development workflow, including debugging and running tests
+* Coding guidelines
+* Submitting pull requests
+* [Finding an issue to work on](https://github.com/NuGet/Home/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+Grabs%22)
+* And much more!
+
+**Note:** Not all of our repositories are open for contribution yet. Ping us if unsure.
+
+## Feedback
+
+* [Ask a question on Stack Overflow](https://stackoverflow.com/questions/tagged/nuget)
+* [Request a new feature](https://github.com/NuGet/Home/wiki/Submitting-Bugs-and-Suggestions#suggestions-and-feature-requests)
+* [Upvote popular feature requests](https://github.com/NuGet/Home/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)
+* [File an issue](https://github.com/NuGet/Home/wiki/Submitting-Bugs-and-Suggestions#before-submitting-an-issue)
+* Follow [@nuget](https://twitter.com/nuget) and let us know what you think!
+
+If you're having trouble with the NuGet.org Website, file a bug on the [NuGet Gallery Issue Tracker](https://github.com/nuget/NuGetGallery/issues). 
+
+If you're having trouble with the NuGet client tools (the Visual Studio extension, NuGet.exe command line tool, etc.), file a bug on [NuGet Home](https://github.com/nuget/home/issues).
+
 ## Repos and Projects
 
 * [NuGet client tools](https://github.com/nuget/nuget.client) - this repo contains the following clients:
@@ -46,11 +77,3 @@ A [full list of all the repos](https://github.com/NuGet) is available as well.
 ## NuGet Packages by the NuGet team
 
 We dogfood all of our stuff. NuGet uses NuGet to build NuGet, so to speak. All of our NuGet packages, which you can use in your own projects as well, are available from [our NuGet.org profile page](https://www.nuget.org/profiles/nuget).
-
-## Feedback
-
-If you're having trouble with the NuGet.org Website, file a bug on the [NuGet Gallery Issue Tracker](https://github.com/nuget/NuGetGallery/issues). 
-
-If you're having trouble with the NuGet client tools (the Visual Studio extension, NuGet.exe command line tool, etc.), file a bug on [NuGet Home](https://github.com/nuget/home/issues).
-
-Check out the [contributing](https://github.com/NuGet/Home/wiki/Contribute-to-NuGet) page to see the best places to log issues and start discussions.  You are welcome to respond to any issues that are marked as ['Up for Grabs'](https://github.com/NuGet/Home/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+Grabs%22) with appropriate pull-requests to address them.  Note that not all of our repositories are open for contribution yet. Ping us if unsure.


### PR DESCRIPTION
Update the NuGet Readme to include more guidance to users regarding how they navigate NuGet/Home. Added additional wiki pages for submitting bugs & suggestions and cleaned up various sidebar items so users can know exactly how they can file an issue, request features, vote on existing features, and much more.

In the future, we'll want to expand the language here to let users know they can also report issues & suggestions through Visual Studio for some of the NuGet repositories like package manager, CLI, etc.