### PR TITLE
Reduce the verbosity of the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@ Is this a regression? Which version:
 
 ## Repro steps and/or sample project
 
-<!-- Please as much details as possible to help us to reproduce your problem. -->
+<!-- Please add as much details as possible to help us to reproduce your problem. -->
 
 ### Verbose Logs
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ NuGet product used (NuGet.exe | Visual Studio | MSBuild.exe | dotnet.exe):
 
 Product version: 
 
-Is this a regression? Which version: 
+Worked before? If so, with which NuGet version: 
 
 ## Repro steps and/or sample project
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,18 +4,16 @@
 
 ## Details about Problem
 
-NuGet tool used (NuGet.exe | VS | MSBuild | dotnet.exe):
+NuGet product used (NuGet.exe | VS | MSBuild | dotnet.exe):
 
-NuGet tool version: 
+Product version: 
 
-Worked before? If so, when:
+Is this a regression? Which version: 
 
 ## Repro steps and/or sample project
 
-1.
-
-1.
+<!-- Please as much details as possible to help us to reproduce your problem. -->
 
 ### Verbose Logs
 
-Please include verbose logs (NuGet.exe <COMMAND> -verbosity detailed | dotnet.exe <COMMAND> --verbosity diag | etc...)
+<!-- Please include verbose logs (NuGet.exe <COMMAND> -verbosity detailed | dotnet.exe <COMMAND> --verbosity diag | etc...) -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,41 +1,21 @@
-Please read the following information before posting the issue.
-
-## Before posting the issue...
-
-* If you're having trouble with the NuGet.org Website, please post in [NuGetGallery issues](http://github.com/nuget/nugetgallery/issues)
-* If you're having trouble with the NuGet client tools (the Visual Studio extension, NuGet.exe command line tool, etc.), you are in the right place.
-
-Remove the content above here and fill out details below.
+<!-- Please read the following information before posting the issue. -->
+<!-- If you're having trouble with the NuGet client tools (the Visual Studio extension, NuGet.exe command line tool, etc.), you are in the right place. -->
+<!-- If you're having trouble with the NuGet.org Website, please post in [NuGetGallery issues](http://github.com/nuget/nugetgallery/issues) -->
 
 ## Details about Problem
 
-NuGet product used (NuGet.exe | VS UI | Package Manager Console | dotnet.exe):
+NuGet tool used (NuGet.exe | VS | MSBuild | dotnet.exe):
 
-NuGet version (x.x.x.xxx):
+NuGet tool version: 
 
-dotnet.exe --version (if appropriate):
+Worked before? If so, when:
 
-VS version (if appropriate):
-
-OS version (i.e. win10 v1607 (14393.321)):
-
-Worked before? If so, with which NuGet version:
-
-## Detailed repro steps so we can see the same problem
+## Repro steps and/or sample project
 
 1.
 
-2.
-
-...
-
-## Other suggested things
+1.
 
 ### Verbose Logs
 
 Please include verbose logs (NuGet.exe <COMMAND> -verbosity detailed | dotnet.exe <COMMAND> --verbosity diag | etc...)
-
-### Sample Project
-
-Very helpful if you can zip a project and paste into this issue!
-

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Details about Problem
 
-NuGet product used (NuGet.exe | VS | MSBuild | dotnet.exe):
+NuGet product used (NuGet.exe | Visual Studio | MSBuild.exe | dotnet.exe):
 
 Product version: 
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/10441


The current issue template is pretty verbose, contains information that we do not need/doesn't deviate usually and often time it leads to people deleting it altogether. 

These changes are meant to reduce the visual strain one has when looking at a new issue and improve issue quality by having something customers would be willing to follow instead of delete.

Note that this is a template tailored towards bugs. We could use a feature template, but that's something we don't have now, so I'm not yet introducing it. 

I came up with this template by looking at template from partner repos: 

https://github.com/microsoft/vscode/issues/new?assignees=&labels=&template=bug_report.md
https://github.com/dotnet/project-system/issues/new
https://github.com/dotnet/runtime/issues/new?assignees=&labels=&template=01_bug_report.md&title=


Note how all of those templates are significantly less verbose than ours.