### PR TITLE
Add NuGet SDK and other options to affected product in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -21,6 +21,8 @@ body:
         - NuGet.exe
         - Visual Studio Package Management UI
         - Visual Studio Package Manager Console
+        - NuGet SDK
+        - Other/NA
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/DCR.yml
+++ b/.github/ISSUE_TEMPLATE/DCR.yml
@@ -23,6 +23,8 @@ body:
         - Visual Studio Package Manager Console
         - MSBuild.exe
         - dotnet.exe
+        - NuGet SDK
+        - Other/NA
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE.yml
@@ -21,6 +21,8 @@ body:
         - Visual Studio Package Manager Console
         - MSBuild.exe
         - dotnet.exe
+        - NuGet SDK
+        - Other/NA
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
The issue templates force everyone to choose a product, but not all issues are related to the options available. This PR gives additional options to avoid selecting an incorrect value just to get the issue created.