### PR TITLE
transitive list is expanded by default

### DIFF
--- a/proposed/2020/Transitive-Dependencies.md
+++ b/proposed/2020/Transitive-Dependencies.md
@@ -68,7 +68,7 @@ Tracking issue can be found here: https://github.com/NuGet/Home/issues/11625
 
 Within Visual Studio, there will be a new panel within the Visual Studio Package Manager UI named “Transitive Packages” in which all transitive packages will be displayed to the user. For the sake of not confusing the user, there will additionally be a header titled “Top-level Packages” where the current experience is today for top-level packages.
 
-**By default, a user’s transitive packages will be collapsed** as a project can have hundreds, if not thousands of transitive packages & would potentially impact performance displaying these many records on each load.
+**By default, a user’s transitive packages will be expanded** to ensure that vulnerability and deprecation notices are discoverable.
 
 When a user highlights a transitive package, they will see a pop-up that displays how the transitive dependency originated & what top-level package(s) are bringing it in.
 
@@ -82,7 +82,7 @@ Finally, selecting a transitive dependency will provide the user the ability to 
 
 * **Labels:** List groups will be labeled “Top-level packages” and “Transitive packages” respectively 
 * **Count:** List groups will display the number of packages in the group 
-* **Default state:** Transitive packages list group will be collapsed by default 
+* **Default state:** Transitive packages list group will be expanded by default
 * **Warnings:** List group headers will surface a warning icon for vulnerabilities and deprecations - see “Vulnerabilities and deprecation” section for relevant details 
 
 **Package items:** The packages under the “Transitive packages” list group will have the same appearance/design as the “Top level packages” (Id, description, author, versions on the right, etc.) 

--- a/proposed/2020/Transitive-Dependencies.md
+++ b/proposed/2020/Transitive-Dependencies.md
@@ -78,7 +78,7 @@ Finally, selecting a transitive dependency will provide the user the ability to 
 
 #### Detailed design
 
-**Collapsible, vertical list group:** Direct and transitive packages will be grouped under collapsible list group
+**Collapsible, vertical list group:** Direct and transitive packages will be grouped under collapsible list group (both expanded by default).
 
 * **Labels:** List groups will be labeled “Top-level packages” and “Transitive packages” respectively 
 * **Count:** List groups will display the number of packages in the group 
@@ -127,7 +127,7 @@ Finally, selecting a transitive dependency will provide the user the ability to 
 There are three primary elements that will be added as part of this design to the existing Visual Studio Package Manager UI.
 
 1.	ScrollViewer – To show transitive dependency nodes.
-2.	Expander – To collapse transitive dependency nodes by default & expand upon user action. To collapse top-level dependency nodes.
+2.	Expander – To collapse and expand transitive dependencies node (expanded by default).
 3.	Tooltip – To show the transitive dependency’s origin.
 
 The actual elements that will be implemented is up to the individual to which would best represent showing a scrollable list of transitive dependencies, collapse them, and provide a hover experience. These elements are simply the closest controls I found to convey the design.

--- a/proposed/2020/Transitive-Dependencies.md
+++ b/proposed/2020/Transitive-Dependencies.md
@@ -91,7 +91,7 @@ Finally, selecting a transitive dependency will provide the user the ability to 
 
 **Search:** Searching for a package ID will filter the packages shown in both list groups in the same way. 
 * Searching for “Microsoft” will show all relevant filtered results for both the top level and transitive packages 
-* If one list group or the other is collapsed, they will remain collapsed on search 
+* If one list group or the other is collapsed, they will be expanded on search
 * The counter for the number of packages will change to reflect the number of packages being shown when filtered with a search query 
 
 **Package details window:** The package details window will be the exact same for transitive and top level packages. 


### PR DESCRIPTION
Transitive header in Installed tab will be expanded by default.