### PR TITLE
Move the issue triage policy to the root & reference it from the contributing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,11 @@ Before embarking on any significant pull request, please ask a maintainer in a G
 
 While creating a pull request, please also include the intent for which you'd like the changes to land. By default, we ask that you pull against the `dev` branch. However if you'd like to see a change in the next service release or preview release of Visual Studio, please communicate with a maintainer of this project to understand if the changes will be able to make the intended release.
 
+## Issue Triage Policy
+
+The NuGet team receives a significant amount of bugs and feature requests and while we'd love to address everyone's concern, this isn't practical.
+[Read more about our issue triage policy.](.\Issue-Triage-Policy.md)
+
 ## Contributing Fixes
 If you are interested in fixing issues and contributing directly to the code base, please see the document [Contribute To NuGet](https://github.com/NuGet/Home/wiki/Contribute-to-NuGet).
 

--- a/Issue-Triage-Policy.md
+++ b/Issue-Triage-Policy.md
@@ -1,4 +1,4 @@
-# Issues Triaging
+# Issues Triage Policy
 Triaging an issue is a multi-step process that is collaboratively performed by the HotSeat, the triage meeting, area owners, and our issue bot. Triaging an issue usually takes around one week but may take longer, for example, when the feature area owner is not around, or we need more information.
 
 ## Our Triaging Flow


### PR DESCRIPTION
See https://github.com/NuGet/Home/pull/11821#issuecomment-1136095380.,