### PR TITLE
Export FabricBot configuration to fabricbot.json file and add it to home repo

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,271 @@
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "vsfeedback"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "Copied from original issue"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "Issue moved from"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Manage \"WaitingFor\" labels] [4-1] Tag \"Transferred issue\" if it's transferred from vsfeedback or other github repo.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Transferred issue"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Triage:Untriaged"
+            }
+          }
+        ]
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "WaitingForCustomer"
+              }
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "operator": "and",
+                  "operands": [
+                    {
+                      "name": "hasLabel",
+                      "parameters": {
+                        "label": "Transferred issue"
+                      }
+                    },
+                    {
+                      "operator": "not",
+                      "operands": [
+                        {
+                          "name": "activitySenderHasPermissions",
+                          "parameters": {
+                            "permissions": "write"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": {
+                      "type": "author"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Manage \"WaitingFor\" labels] [4-2] Replace tag \"WaitingForCustomer\" with \"WaitingForClientTeam\" when the author comments on an issue. Also remove `Status: No Recent Activity` if it's been set.",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "WaitingForCustomer"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "WaitingForClientTeam"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          }
+        ]
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "closed"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "WaitingForClientTeam"
+                  }
+                },
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "WaitingForCustomer"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Manage \"WaitingFor\" labels] [4-3] Remove any \"WaitingFor\" label when the issue is closed",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "WaitingForClientTeam"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "WaitingForCustomer"
+            }
+          }
+        ]
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "WaitingForClientTeam"
+              }
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "write"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Manage \"WaitingFor\" labels] [4-4] Replace tag \"WaitingForClientTeam\" with \"WaitingForCustomer\" when client team comments on an issue.",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "WaitingForClientTeam"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "WaitingForCustomer"
+            }
+          }
+        ]
+      },
+      "disabled": false
+    }
+  ],
+  "userGroups": []
+}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/1695

Regression? Last working version: N/A

Description
As FabricBot recently removed the "save" button and move FabricBot to be a [config-as-code-only](https://1esdocs.azurewebsites.net/datainsights/merlinbot/extensions/Bot-config-as-code.html) platform, we need to export existing NuGet/Home repo fabricbot configurations to a config file named .github\fabricbot.json.

For adding new rulesets into the configuration in the future, we will need to wait for the "inflight mode" feature. So that we could test the new rulesets before merging PRs(changing this .github\fabricbot.json file).