### PR TITLE
Add stale waiting for customer bots

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -130,7 +130,7 @@
         "eventNames": [
           "issue_comment"
         ],
-        "taskName": "[Manage \"WaitingFor\" labels] [4-2] Replace tag \"WaitingForCustomer\" with \"WaitingForClientTeam\" when the author comments on an issue. Also remove `Status: No Recent Activity` if it's been set.",
+        "taskName": "[Manage \"WaitingFor\" labels] [4-2] Replace tag \"WaitingForCustomer\" with \"WaitingForClientTeam\" when the author comments on an issue. Also remove `Status:No recent activity` if it's been set.",
         "actions": [
           {
             "name": "removeLabel",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -821,7 +821,7 @@
             }
           }
         ],
-        "taskName": "[Managed stale WaitingForCustomer] Search for WaitingForCustomer issues with no activity over 14 days and warn.",
+        "taskName": "[Manage stale WaitingForCustomer issues] Search for WaitingForCustomer issues with no activity over 14 days and warn.",
         "actions": [
           {
             "name": "addLabel",
@@ -833,6 +833,151 @@
             "name": "addReply",
             "parameters": {
               "comment": "This issue has been automatically marked as stale because we have not received a response in 14 days. It will be closed if no further activity occurs within another 14 days of this comment."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.0",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          },
+          {
+            "noActivitySince": "14",
+            "parameters": {
+              "days": 14
+            }
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ],
+        "taskName": "[Close stale WaitingForCustomer issues] Search for stale WaitingForCustomer issues with no activity over 14 days and warn.",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Resolution:NeedMoreInfo"
             }
           }
         ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -752,7 +752,7 @@
             }
           },
           {
-            "noActivitySince": "14",
+            "name": "noActivitySince",
             "parameters": {
               "days": 14
             }
@@ -854,7 +854,7 @@
             }
           },
           {
-            "noActivitySince": "14",
+            "name": "noActivitySince",
             "parameters": {
               "days": 14
             }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -871,6 +871,10 @@
         "taskName": "[Close stale WaitingForCustomer issues] Search for stale WaitingForCustomer issues with no activity over 14 days and warn.",
         "actions": [
           {
+            "name": "closeIssue",
+            "parameters": {}
+          },
+          {
             "name": "removeLabel",
             "parameters": {
               "label": "Status:No recent activity"

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -697,98 +697,49 @@
           {
             "weekDay": 0,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 1,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 2,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 3,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 4,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 5,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 6,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           }
@@ -848,98 +799,49 @@
           {
             "weekDay": 0,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 1,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 2,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 3,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 4,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 5,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           },
           {
             "weekDay": 6,
             "hours": [
-              0,
-              3,
-              6,
-              9,
-              12,
-              15,
-              18,
-              21
+              6
             ],
             "timezoneOffset": -7
           }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -686,6 +686,157 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.0",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "WaitingForCustomer"
+            }
+          },
+          {
+            "noActivitySince": "14",
+            "parameters": {
+              "days": 14
+            }
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          }
+        ],
+        "taskName": "[Managed stale WaitingForCustomer] Search for WaitingForCustomer issues with no activity over 14 days and warn.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Status:No recent activity"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has been automatically marked as stale because we have not received a response in 14 days. It will be closed if no further activity occurs within another 14 days of this comment."
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
Fixes https://github.com/NuGet/Client.Engineering/issues/1038

1.	Client people manually add "WaitingForCustomer" label if needs input from customer.
2.	When customer replies/ or if any response if it’s an issue transferred from other repo/VSFeedback, remove the "WaitingForCustomer"  label and add "WaitingForClientTeam"  label.
3.	When no response after an issue adding a "WaitingForCustomer" label for 14 days, add a "Status: No recent activity"  label, add a comment, e.g.
4.	Close the issue if there is no activity for 14 days after .
Remove any "WaitingForCustomer"  or  "WaitingForClientTeam" label when the issue is closed and add `Resolution:Need more info`

This was tested in 
 https://github.com/NuGet/bot-testing/issues/13 and https://github.com/NuGet/bot-testing/issues/12
 
 Currently on 5 issues have the potential to be reported by these bots: 
 
 https://github.com/NuGet/Home/issues?q=is%3Aopen+is%3Aissue+label%3AWaitingForCustomer

I will monitor these individual issues. 
4 of these issues sohuld get the `Status:No recent activity` label immediately.