### PR TITLE
Add spec of dotnet nuget config command

### DIFF
--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -74,7 +74,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-- List all the NuGet configuration file that will be applied, but passing a non-exsiting `WORKING_DIRECTORY`.
+- List all the NuGet configuration file that will be applied, but passing a non-exsiting `--working-directory`.
 
 ```
 dotnet nuget config path  --working-directory C:\Test\NonExistingRepos
@@ -82,7 +82,7 @@ dotnet nuget config path  --working-directory C:\Test\NonExistingRepos
 Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 ```
 
-- List all the NuGet configuration file that will be applied, but passing an inaccessible `WORKING_DIRECTORY`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
+- List all the NuGet configuration file that will be applied, but passing an inaccessible `--working-directory`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
 
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
@@ -338,7 +338,10 @@ dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppD
 ## Future Work
 1. The `dotnet nuget config path/get` is a community ask. We will discuss if adding this command into NuGet.exe CLI, in the future.
 2. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. 
-But the behavior is confusing: the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file. We might need to change this behavior in the future. (Related code: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L229)
+But the behavior is confusing: the `set` command will set the property which appears last when loading(for all writable files), so it's not updating the closest NuGet configuration file, but the user-wide NuGet configuration file.(Related code: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L229)
+We keep the behavior of `dotnet nuget config set` the same with above for now.
+But we might need to change this behavior in the future. 
+Considering this will be a breaking change, we will only consider doing it in main version change, if there are enough votes.
 
 ## Open Questions
 1. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -26,10 +26,9 @@ The following command will be implemented in the `dotnet.exe` CLI.
 
 - List
 
-Lists all the NuGet configuration file locations. 
+Lists all the NuGet configuration settings. 
 
-This command will include all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path. The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
-You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
+This command will list merged NuGet configuration settings from one or multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
 
 #### Arguments
 
@@ -46,7 +45,10 @@ If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indica
 - -v|--verbosity <LEVEL>
 
 Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
-When the verbosity level is detailed or diagnostic, the command will display the merged NuGet configuration.
+When the verbosity level is detailed or diagnostic, the command will display all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path.
+
+The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
+You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
 - -?|-h|--help
 
@@ -57,7 +59,25 @@ Prints out a description of how to use the command.
 - List all the NuGet configuration file that will be applied, when invoking NuGet command in the current directory.
 
 ```
-dotnet nuget config list
+dotnet nuget config list --verbosity detailed
+
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+  <bindingRedirects>
+    <add key="skip" value="False" />
+  </bindingRedirects>
+  <packageManagement>
+    <add key="format" value="0" />
+    <add key="disabled" value="False" />
+  </packageManagement>
+</configuration>
 
 C:\Test\Repos\Solution\NuGet.Config
 C:\Test\Repos\NuGet.Config
@@ -70,27 +90,39 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the NuGet configuration file that will be applied, when invoking NuGet command in the specific directory.
 
 ```
+dotnet nuget config list  C:\Test\Repos --verbosity detailed
+
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+    <add key="Test Package source" value="C:\work" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+  <bindingRedirects>
+    <add key="skip" value="False" />
+  </bindingRedirects>
+  <packageManagement>
+    <add key="format" value="0" />
+    <add key="disabled" value="False" />
+  </packageManagement>
+</configuration>
+
+C:\Test\Repos\NuGet.Config
+C:\Test\NuGet.Config
+C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
+```
+
+- List only the NuGet configuration settings, when invoking NuGet command in the specific directory.
+
+```
 dotnet nuget config list  C:\Test\Repos
 
-C:\Test\Repos\NuGet.Config
-C:\Test\NuGet.Config
-C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
-C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
-C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
-```
-
-- List all the NuGet configuration file that will be applied, and show the merged NuGet configuration, when invoking NuGet command in the specific directory.
-
-```
-dotnet nuget config list  C:\Test\Repos -v d
-
-C:\Test\Repos\NuGet.Config
-C:\Test\NuGet.Config
-C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
-C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
-C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
-
-The merged NuGet configuration:
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
@@ -125,7 +157,26 @@ Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config list  C:\Test\AccessibleRepos\NotAccessibleSolution
+dotnet nuget config list  C:\Test\AccessibleRepos\NotAccessibleSolution -v d
+
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+    <add key="Test Package source" value="C:\work" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+  <bindingRedirects>
+    <add key="skip" value="False" />
+  </bindingRedirects>
+  <packageManagement>
+    <add key="format" value="0" />
+    <add key="disabled" value="False" />
+  </packageManagement>
+</configuration>
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -36,6 +36,7 @@ You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nu
 Prints out a description of how to use the command.
 
 - --current-directory
+
 Run this command as if current directory is set to the specified directory.
 
 #### Examples

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -185,6 +185,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
+#### Commands
 
 - Set
 
@@ -282,8 +283,9 @@ dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppD
 3. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
 
 ## Open Questions
-1. What are the recommended verbs in dotnet command when setting and unsetting values?  ('set' and 'unset' work or not?)
-2. `Get` is not mentioned in this doc. It may cause some confusions:
+1. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+2. What are the recommended verbs in dotnet command when setting and unsetting values?  ('set' and 'unset' work or not?)
+3. `Get` is not mentioned in this doc. It may cause some confusions:
    Should `get` work for settings not in config section? (It's workable, but then we will miss `set` and `unset` for those as those are not doable)
    Should `get` get the settings from a specific config file(like `set` and `unset`), or get the merged settings from multiple config files?
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -358,6 +358,8 @@ Considering this will be a breaking change, we will only consider doing it in ma
 1. Will this command help with diagnosing incorrect setting format?
 <br />No. Incorrect NuGet settings should have seperate error/warning message to tell the customer what's wrong in the setting file. If we have incorrect NuGet settings, all NuGet command, including `dotnet nuget config` command, should display the same error/warning message.
 <br />E.g. if we have an invalid XML problem in one of the NuGet configuration file, running all NuGet command will get an error as following:
+```
 dotnet nuget list source
 error: NuGet.Config is not valid XML. Path: 'C:\Users\username\Source\Repos\NuGet.Config'.
 error:   The 'disabledPackageSources' start tag on line 19 position 4 does not match the end tag of 'configuration'. Line 20, position 3.
+```

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -291,10 +291,8 @@ dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppD
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?
-No. Incorrect NuGet settings should have seperate error/warning message to tell the customer what's wrong in the setting file. If we have incorrect NuGet settings, all NuGet command, including `dotnet nuget config` command, should display the same error/warning message.
-E.g. if we have an invalid XML problem in one of the NuGet configuration file, running all NuGet command will get an error as following:
-```
+<br />No. Incorrect NuGet settings should have seperate error/warning message to tell the customer what's wrong in the setting file. If we have incorrect NuGet settings, all NuGet command, including `dotnet nuget config` command, should display the same error/warning message.
+<br />E.g. if we have an invalid XML problem in one of the NuGet configuration file, running all NuGet command will get an error as following:
 dotnet nuget list source
 error: NuGet.Config is not valid XML. Path: 'C:\Users\username\Source\Repos\NuGet.Config'.
 error:   The 'disabledPackageSources' start tag on line 19 position 4 does not match the end tag of 'configuration'. Line 20, position 3.
-```

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -305,14 +305,6 @@ If the specified `CONFIG_KEY` is not a key in [config section](https://learn.mic
 
 - --config-file
 
-Specify the config file path to remove the setting key-value pair. If it's not specified, the config file with highest priority will be updated.
-
-- -?|-h|--help
-
-Prints out a description of how to use the command.
-
-- --config-file
-
 Specify the config file path to remove the setting key-value pair. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
 
 - -?|-h|--help
@@ -337,6 +329,7 @@ dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppD
 
 ## Future Work
 1. The `dotnet nuget config path/get` is a community ask. We will discuss if adding this command into NuGet.exe CLI, in the future.
+
 2. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. 
 But the behavior is confusing: the `set` command will set the property which appears last when loading(for all writable files), so it's not updating the closest NuGet configuration file, but the user-wide NuGet configuration file.(Related code: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L229)
 We keep the behavior of `dotnet nuget config set` the same with above for now.

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -1,21 +1,21 @@
-# dotnet nuget config command
+# NuGet configuration CLI for dotnet.exe
 
 - Author: [Heng Liu](https://github.com/heng-liu)
 - GitHub Issue [8420](https://github.com/NuGet/Home/issues/8420)
 
 ## Problem Background
 
-Currently, there is no command for NuGet users to know about the NuGet configuration file locations. This is inconvienient for both NuGet users and NuGet team. When NuGet users want to figure out where is the merged configuration coming from, or when NuGet team tries to diagnose issues but needs all the configuration files, this command will be helpful.
+Currently, there is no NuGet configuration CLI for dotnet.exe. It's inconvenient for NuGet users to know about the NuGet configuration file locations and figure out where is the merged configuration coming from. 
 
 ## Who are the customers
 
 This feature is for dotnet.exe users.
 
 ## Goals
-Design and implement `dotnet nuget config list` commands.
+Design and implement `dotnet nuget config` command.
 
 ## Non-Goals
-Design and implement other `dotnet nuget config` commands. E.g. add/update/delete
+Design and implement `dotnet nuget config` command with commands other than `list`, E.g. add/update/delete
 
 ## Solution
 The following command will be implemented in the `dotnet.exe` CLI.
@@ -49,10 +49,13 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-### Future Work
+## Future Work
 The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
 
 ## Open Questions
 1. Shall we add `working directory` as an option? So that people could check different NuGet configuration lists without changing current directory.
 2. Do we need to add this into NuGet.exe CLI?
+
+## Considerations
+1. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -35,9 +35,12 @@ You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nu
 
 Prints out a description of how to use the command.
 
+- --current-directory
+Run this command as if current directory is set to the specified directory.
+
 #### Examples
 
-- List all the NuGet configuration file that will be applied.
+- List all the NuGet configuration file that will be applied, when invoking NuGet command in the current directory.
 
 ```
 dotnet nuget config list
@@ -49,12 +52,21 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
+- List all the NuGet configuration file that will be applied, when invoking NuGet command in the specific directory.
+```
+dotnet nuget config list --current-directory c:\repos\Solution
+
+c:\repos\Solution\NuGet.Config
+C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
+```
+
 ## Future Work
 The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
 
 ## Open Questions
-1. Shall we add `working directory` as an option? So that people could check different NuGet configuration lists without changing current directory.
-2. Do we need to add this into NuGet.exe CLI?
+1. Do we need to add this into NuGet.exe CLI?
 
 ## Considerations
 1. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -30,14 +30,15 @@ If no command is specified, the command will default to list.
 Lists all the NuGet configuration file locations. This command will include all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path. The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
 You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
+#### Arguments
+- CURRENT_DIRECTORY
+
+Run this command as if current directory is set to the specified directory.
+
 #### Options
 - -?|-h|--help
 
 Prints out a description of how to use the command.
-
-- --current-directory
-
-Run this command as if current directory is set to the specified directory.
 
 #### Examples
 
@@ -46,18 +47,21 @@ Run this command as if current directory is set to the specified directory.
 ```
 dotnet nuget config list
 
-c:\repos\Solution\Project\NuGet.Config
-c:\repos\Solution\NuGet.Config
+C:\Test\Repos\Solution\NuGet.Config
+C:\Test\Repos\NuGet.Config
+C:\Test\NuGet.Config
 C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
 - List all the NuGet configuration file that will be applied, when invoking NuGet command in the specific directory.
-```
-dotnet nuget config list --current-directory c:\repos\Solution
 
-c:\repos\Solution\NuGet.Config
+```
+dotnet nuget config list  C:\Test\Repos
+
+C:\Test\Repos\NuGet.Config
+C:\Test\NuGet.Config
 C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -186,12 +186,106 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
 
+- Set
+
+Set the NuGet configuration settings. 
+
+This command will set the value of a specified NuGet configuration setting.
+
+Please note this command only manages settings in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section).
+For other settings not in config section, we have/will have other commands. E.g. for [trustedSigners section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section), we have [dotnet nuget trust](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust) command.
+
+#### Arguments
+
+- SETTING_KEY
+
+Specify the key of the settings that are to be set.
+
+If the specified `SETTING_KEY` is not a key in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section), an error is displayed indicating the `SETTING_KEY` could not be set.
+
+- SETTING_VALUE
+
+Set the value of the SETTING_KEY to SETTING_VALUE.
+
+#### Options
+- --config-file
+
+Specify the config file path to add the setting key-value pair. If it's not specified, the config file with highest priority will be updated.
+
+- -?|-h|--help
+
+Prints out a description of how to use the command.
+
+#### Examples
+
+- Set the `signatureValidationMode` to true in the closest NuGet configuration file.
+
+```
+dotnet nuget config set signatureValidationMode require
+
+```
+
+- Set the `defaultPushSource` in the specified NuGet configuration file.
+
+```
+dotnet nuget config set defaultPushSource https://MyRepo/ES/api/v2/package --config-file C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+
+```
+
+- Unset
+
+Remove the NuGet configuration settings. 
+
+This command will remove the key-value pair from a specified NuGet configuration setting.
+
+Please note this command only manages settings in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section).
+For other settings not in config section, we have/will have other commands. E.g. for [trustedSigners section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section), we have [dotnet nuget trust](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust) command.
+
+#### Arguments
+
+- SETTING_KEY
+
+Specify the key of the settings that are to be removed.
+
+If the specified `SETTING_KEY` is not a key in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section), an error is displayed indicating the `SETTING_KEY` could not be set.
+
+
+#### Options
+
+- --config-file
+
+Specify the config file path to remove the setting key-value pair. If it's not specified, the config file with highest priority will be updated.
+
+- -?|-h|--help
+
+Prints out a description of how to use the command.
+
+#### Examples
+
+- Unset the `signatureValidationMode` in the closest NuGet configuration file.
+
+```
+dotnet nuget config unset signatureValidationMode
+
+```
+
+- Unset the `defaultPushSource` in the specified NuGet configuration file.
+
+```
+dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+
+```
+
 ## Future Work
 1. The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
 2. We will discuss if adding this command into NuGet.exe CLI, in the future.
 3. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
 
 ## Open Questions
+1. What are the recommended verbs in dotnet command when setting and unsetting values?  ('set' and 'unset' work or not?)
+2. `Get` is not mentioned in this doc. It may cause some confusions:
+   Should `get` work for settings not in config section? (It's workable, but then we will miss `set` and `unset` for those as those are not doable)
+   Should `get` get the settings from a specific config file(like `set` and `unset`), or get the merged settings from multiple config files?
 
 ## Considerations
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -1,0 +1,58 @@
+# dotnet nuget config command
+
+- Author: [Heng Liu](https://github.com/heng-liu)
+- GitHub Issue [8420](https://github.com/NuGet/Home/issues/8420)
+
+## Problem Background
+
+Currently, there is no command for NuGet users to know about the NuGet configuration file locations. This is inconvienient for both NuGet users and NuGet team. When NuGet users want to figure out where is the merged configuration coming from, or when NuGet team tries to diagnose issues but needs all the configuration files, this command will be helpful.
+
+## Who are the customers
+
+This feature is for dotnet.exe users.
+
+## Goals
+Design and implement `dotnet nuget config list` commands.
+
+## Non-Goals
+Design and implement other `dotnet nuget config` commands. E.g. add/update/delete
+
+## Solution
+The following command will be implemented in the `dotnet.exe` CLI.
+
+### `dotnet nuget config`
+
+#### Commands
+If no command is specified, the command will default to list.
+
+- List
+
+Lists all the NuGet configuration file locations. This command will include all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path. The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
+You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
+
+#### Options
+- -?|-h|--help
+
+Prints out a description of how to use the command.
+
+#### Examples
+
+- List all the NuGet configuration file that will be applied.
+
+```
+dotnet nuget config list
+
+c:\repos\Solution\Project\NuGet.Config
+c:\repos\Solution\NuGet.Config
+C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
+```
+
+### Future Work
+The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
+
+## Open Questions
+1. Shall we add `working directory` as an option? So that people could check different NuGet configuration lists without changing current directory.
+2. Do we need to add this into NuGet.exe CLI?
+

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -144,20 +144,18 @@ When the verbosity level is detailed or diagnostic, the source(NuGet configurati
 dotnet nuget config get all
 
 packageSources:
-  "source1" value="https://test/source1/v3/index.json"
-  "source2" value="https://test/source2/v3/index.json"
+  clear
+  add key="source1" value="https://test/source1/v3/index.json"
+  add key="source2" value="https://test/source2/v3/index.json"
 
 packageSourceMapping:
   clear
-  "source1" 
-    pattern="microsoft.*"
-    pattern="nuget.*"
-  "source2" 
-    pattern="system.*"
+  packageSource key="source1"  pattern="microsoft.*","nuget.*"
+  packageSource key="source2"  pattern="system.*"
 
 packageRestore:
-  "enabled" value="False"
-  "automatic" value="False"
+  add key="enabled" value="False"
+  add key="automatic" value="False"
 
 ```
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the specific directory.
@@ -166,20 +164,18 @@ packageRestore:
 dotnet nuget config get all --working-dir C:\Test\Repos
 
 packageSources:
-  "source1" value="https://test/source1/v3/index.json"
-  "source2" value="https://test/source2/v3/index.json"
+  clear
+  add key="source1" value="https://test/source1/v3/index.json"
+  add key="source2" value="https://test/source2/v3/index.json"
 
 packageSourceMapping:
   clear
-  "source1" 
-    pattern="microsoft.*"
-    pattern="nuget.*"
-  "source2" 
-    pattern="system.*"
+  packageSource key="source1"  pattern="microsoft.*","nuget.*"
+  packageSource key="source2"  pattern="system.*"
 
 packageRestore:
-  "enabled" value="False"
-  "automatic" value="False"
+  add key="enabled" value="False"
+  add key="automatic" value="False"
 
 ```
 
@@ -189,20 +185,17 @@ packageRestore:
 dotnet nuget config get all -v d
 
 packageSources:
-  "source1" value="https://test/source1/v3/index.json"     file: C:\Test\Repos\Solution\NuGet.Config
-  "source2" value="https://test/source2/v3/index.json"     file: C:\Test\Repos\NuGet.Config
+  add key="source1" value="https://test/source1/v3/index.json"     file: C:\Test\Repos\Solution\NuGet.Config
+  add key="source2" value="https://test/source2/v3/index.json"     file: C:\Test\Repos\NuGet.Config
 
 packageSourceMapping:
-  clear                                                   file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
-  "source1"                                               file: C:\Test\Repos\Solution\NuGet.Config
-    pattern="microsoft.*"
-    pattern="nuget.*"
-  "source2" 
-    pattern="system.*"                                    file: C:\Test\Repos\NuGet.Config
+  clear                                                            file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+  packageSource key="source1"  pattern="microsoft.*","nuget.*"     file: C:\Test\Repos\Solution\NuGet.Config
+  packageSource key="source2"  pattern="system.*"                  file: C:\Test\Repos\NuGet.Config                                 
 
 packageRestore:
-  "enabled" value="False"                                 file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
-  "automatic" value="False"                               file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+  add key="enabled" value="False"                                 file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+  add key="automatic" value="False"                               file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 
 ```
 
@@ -335,13 +328,24 @@ Considering this will be a breaking change, we will only consider doing it in ma
 ## Open Questions
 1. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
 
-2. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). But
-`dotnet nuget config get` will get all merged configuration settings in xml format, since many sections are not simple key-value pairs.
- Do we need to have another verb for getting all merged configuration settings? 
+2. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
+```
+packageSources:
+  clear
+  add key="source1" value="https://test/source1/v3/index.json"
+  add key="source2" value="https://test/source2/v3/index.json"
 
-3. `dotnet nuget config get -v d` will display source of each configuration setting key, in a format of comment in xml file. So that people can still redirect the output into a file without breaking any syntax. Does that sound good to you?
+packageSourceMapping:
+  clear
+  packageSource key="source1"  pattern="microsoft.*","nuget.*"
+  packageSource key="source2"  pattern="system.*"
 
-3. `--working-dir` is changed from an argument into an option. Because we could not differentiate `dotnet nuget config get <WORKING_DIRECTORY>` and `dotnet nuget config get <CONFIG_KEY>`. Any better ideas?
+packageRestore:
+  add key="enabled" value="False"
+  add key="automatic" value="False"
+```
+
+3. `--working-dir` is changed from an argument into an option. (Follow the example of Dotnet store command. It has -w|--working-dir <WORKING_DIRECTORY> option https://learn.microsoft.com/dotnet/core/tools/dotnet-store#optional-options).
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -69,11 +69,16 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
 ## Future Work
-The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
+1. The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
+2. We will discuss if adding this command into NuGet.exe CLI, in the future.
+3. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
 
 ## Open Questions
-1. Do we need to add this into NuGet.exe CLI?
+1. When the specified `CURRENT_DIRECTORY` doesn't exist, shall we list user-wide and machine-wide config files? Or show a warning saying the working directory doesn't exist? Or do both?
+
+I prefer do just a warning, or do both. 
+When user has a spelling mistake when passing `CURRENT_DIRECTORY` without knowing, if we don't show a warning, that would mislead the user.
+Showing them user-wide and machine-wide config files could provide extra info and may help them to understand the example of a right path. But since this is not a real scenario (It's impossible that a real `CURRENT_DIRECTORY` doesn't exist), this adds very limited value.
 
 ## Considerations
-1. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -24,11 +24,12 @@ The following command will be implemented in the `dotnet.exe` CLI.
 
 #### Commands
 
-- List
+- Path
 
-Lists all the NuGet configuration settings. 
+List all the paths of NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path.
 
-This command will list merged NuGet configuration settings from one or multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
+The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
+You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
 #### Arguments
 
@@ -42,13 +43,6 @@ If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indica
 > If `WORKING_DIRECTORY` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
 
 #### Options
-- -v|--verbosity <LEVEL>
-
-Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
-When the verbosity level is detailed or diagnostic, the command will display all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path.
-
-The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
-You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
 - -?|-h|--help
 
@@ -59,25 +53,7 @@ Prints out a description of how to use the command.
 - List all the NuGet configuration file that will be applied, when invoking NuGet command in the current directory.
 
 ```
-dotnet nuget config list --verbosity detailed
-
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
-  </packageSources>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-  <bindingRedirects>
-    <add key="skip" value="False" />
-  </bindingRedirects>
-  <packageManagement>
-    <add key="format" value="0" />
-    <add key="disabled" value="False" />
-  </packageManagement>
-</configuration>
+dotnet nuget config path 
 
 C:\Test\Repos\Solution\NuGet.Config
 C:\Test\Repos\NuGet.Config
@@ -87,29 +63,10 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-- List all the NuGet configuration file that will be applied, when invoking NuGet command in the specific directory.
+- List all the paths of NuGet configuration files that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config list  C:\Test\Repos --verbosity detailed
-
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
-    <add key="Test Package source" value="C:\work" />
-  </packageSources>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-  <bindingRedirects>
-    <add key="skip" value="False" />
-  </bindingRedirects>
-  <packageManagement>
-    <add key="format" value="0" />
-    <add key="disabled" value="False" />
-  </packageManagement>
-</configuration>
+dotnet nuget config path  C:\Test\Repos
 
 C:\Test\Repos\NuGet.Config
 C:\Test\NuGet.Config
@@ -118,36 +75,10 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-- List only the NuGet configuration settings, when invoking NuGet command in the specific directory.
-
-```
-dotnet nuget config list  C:\Test\Repos
-
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
-    <add key="Test Package source" value="C:\work" />
-  </packageSources>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-  <bindingRedirects>
-    <add key="skip" value="False" />
-  </bindingRedirects>
-  <packageManagement>
-    <add key="format" value="0" />
-    <add key="disabled" value="False" />
-  </packageManagement>
-</configuration>
-
-```
-
 - List all the NuGet configuration file that will be applied, but passing a non-exsiting `WORKING_DIRECTORY`.
 
 ```
-dotnet nuget config list  C:\Test\NonExistingRepos
+dotnet nuget config path  C:\Test\NonExistingRepos
 
 Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 ```
@@ -157,26 +88,7 @@ Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config list  C:\Test\AccessibleRepos\NotAccessibleSolution -v d
-
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
-    <add key="Test Package source" value="C:\work" />
-  </packageSources>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-  <bindingRedirects>
-    <add key="skip" value="False" />
-  </bindingRedirects>
-  <packageManagement>
-    <add key="format" value="0" />
-    <add key="disabled" value="False" />
-  </packageManagement>
-</configuration>
+dotnet nuget config list  C:\Test\AccessibleRepos\NotAccessibleSolution
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config
@@ -186,6 +98,11 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
 #### Commands
+- Get
+
+Get the list of all the NuGet configuration settings. 
+
+This command will list merged NuGet configuration settings from one or multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
 
 - Set
 
@@ -212,6 +129,11 @@ Set the value of the SETTING_KEY to SETTING_VALUE.
 - --config-file
 
 Specify the config file path to add the setting key-value pair. If it's not specified, the config file with highest priority will be updated.
+
+- -v|--verbosity <LEVEL>
+
+Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
+When the verbosity level is detailed or diagnostic, 
 
 - -?|-h|--help
 
@@ -274,6 +196,32 @@ dotnet nuget config unset signatureValidationMode
 
 ```
 dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+
+```
+
+- List only the NuGet configuration settings, when invoking NuGet command in the specific directory.
+
+```
+dotnet nuget config list  C:\Test\Repos
+
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+    <add key="Test Package source" value="C:\work" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+  <bindingRedirects>
+    <add key="skip" value="False" />
+  </bindingRedirects>
+  <packageManagement>
+    <add key="format" value="0" />
+    <add key="disabled" value="False" />
+  </packageManagement>
+</configuration>
 
 ```
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -290,4 +290,11 @@ dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppD
    Should `get` get the settings from a specific config file(like `set` and `unset`), or get the merged settings from multiple config files?
 
 ## Considerations
-
+1. Will this command help with diagnosing incorrect setting format?
+No. Incorrect NuGet settings should have seperate error/warning message to tell the customer what's wrong in the setting file. If we have incorrect NuGet settings, all NuGet command, including `dotnet nuget config` command, should display the same error/warning message.
+E.g. if we have an invalid XML problem in one of the NuGet configuration file, running all NuGet command will get an error as following:
+```
+dotnet nuget list source
+error: NuGet.Config is not valid XML. Path: 'C:\Users\username\Source\Repos\NuGet.Config'.
+error:   The 'disabledPackageSources' start tag on line 19 position 4 does not match the end tag of 'configuration'. Line 20, position 3.
+```

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -326,9 +326,13 @@ But we might need to change this behavior in the future.
 Considering this will be a breaking change, we will only consider doing it in main version change, if there are enough votes.
 
 ## Open Questions
-1. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+1. Shall we use `dotnet nuget config get all` or `dotnet nuget config get` to get all configuration settings?
 
-2. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
+2. `--working-dir` is changed from an argument into an option. (Follow the example of Dotnet store command. It has -w|--working-dir <WORKING_DIRECTORY> option https://learn.microsoft.com/dotnet/core/tools/dotnet-store#optional-options). Any other thoughts?
+
+3. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+
+4. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
 ```
 packageSources:
   clear
@@ -344,8 +348,6 @@ packageRestore:
   add key="enabled" value="False"
   add key="automatic" value="False"
 ```
-
-3. `--working-dir` is changed from an argument into an option. (Follow the example of Dotnet store command. It has -w|--working-dir <WORKING_DIRECTORY> option https://learn.microsoft.com/dotnet/core/tools/dotnet-store#optional-options).
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -23,7 +23,6 @@ The following command will be implemented in the `dotnet.exe` CLI.
 ### `dotnet nuget config`
 
 #### Commands
-If no command is specified, the command will default to list.
 
 - List
 
@@ -31,11 +30,13 @@ Lists all the NuGet configuration file locations. This command will include all 
 You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
 #### Arguments
+
 - CURRENT_DIRECTORY
 
 Run this command as if current directory is set to the specified directory.
 
 #### Options
+
 - -?|-h|--help
 
 Prints out a description of how to use the command.

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -43,6 +43,10 @@ If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indica
 > If `WORKING_DIRECTORY` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
 
 #### Options
+- -v|--verbosity <LEVEL>
+
+Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
+When the verbosity level is detailed or diagnostic, the command will display the merged NuGet configuration.
 
 - -?|-h|--help
 
@@ -73,6 +77,39 @@ C:\Test\NuGet.Config
 C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
+```
+
+- List all the NuGet configuration file that will be applied, and show the merged NuGet configuration, when invoking NuGet command in the specific directory.
+
+```
+dotnet nuget config list  C:\Test\Repos -v d
+
+C:\Test\Repos\NuGet.Config
+C:\Test\NuGet.Config
+C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
+
+The merged NuGet configuration:
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
+    <add key="Test Package source" value="C:\work" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+  <bindingRedirects>
+    <add key="skip" value="False" />
+  </bindingRedirects>
+  <packageManagement>
+    <add key="format" value="0" />
+    <add key="disabled" value="False" />
+  </packageManagement>
+</configuration>
+
 ```
 
 - List all the NuGet configuration file that will be applied, but passing a non-exsiting `WORKING_DIRECTORY`.

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -34,14 +34,14 @@ You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nu
 
 #### Options
 
-- --working-directory
+- -w|--working-dir <WORKING_DIRECTORY>
 
 Run this command as if working directory is set to the specified directory.
 
-If the specified `--working-directory` doesn't exist, an error is displayed indicating the `--working-directory` doesn't exist.
+If the specified `--working-dir` doesn't exist, an error is displayed indicating the `--working-dir` doesn't exist.
 
 > [!Note]
-> If `--working-directory` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+> If `--working-dir` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
 
 - -?|-h|--help
 
@@ -65,7 +65,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the paths of NuGet configuration files that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config path  --working-directory C:\Test\Repos
+dotnet nuget config path  --working-dir C:\Test\Repos
 
 C:\Test\Repos\NuGet.Config
 C:\Test\NuGet.Config
@@ -74,20 +74,20 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-- List all the NuGet configuration file that will be applied, but passing a non-exsiting `--working-directory`.
+- List all the NuGet configuration file that will be applied, but passing a non-exsiting `--working-dir`.
 
 ```
-dotnet nuget config path  --working-directory C:\Test\NonExistingRepos
+dotnet nuget config path  --working-dir C:\Test\NonExistingRepos
 
 Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 ```
 
-- List all the NuGet configuration file that will be applied, but passing an inaccessible `--working-directory`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
+- List all the NuGet configuration file that will be applied, but passing an inaccessible `--working-dir`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
 
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config list  --working-directory C:\Test\AccessibleRepos\NotAccessibleSolution
+dotnet nuget config list  --working-dir C:\Test\AccessibleRepos\NotAccessibleSolution
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config
@@ -115,14 +115,14 @@ For other sections, like package source section, we have/will have specific comm
 
 #### Options
 
-- --working-directory
+- -w|--working-dir <WORKING_DIRECTORY>
 
 Run this command as if working directory is set to the specified directory.
 
-If the specified `--working-directory` doesn't exist, an error is displayed indicating the `--working-directory` doesn't exist.
+If the specified `--working-dir` doesn't exist, an error is displayed indicating the `--working-dir` doesn't exist.
 
 > [!Note]
-> If `--working-directory` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+> If `--working-dir` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
 
 - -?|-h|--help
 
@@ -166,7 +166,7 @@ dotnet nuget config get
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config get --working-directory C:\Test\Repos
+dotnet nuget config get --working-dir C:\Test\Repos
 
 <configuration>
   <packageSources>
@@ -345,7 +345,7 @@ Considering this will be a breaking change, we will only consider doing it in ma
 
 3. `dotnet nuget config get -v d` will display source of each configuration setting key, in a format of comment in xml file. So that people can still redirect the output into a file without breaking any syntax. Does that sound good to you?
 
-3. `--working-directory` is changed from an argument into an option. Because we could not differentiate `dotnet nuget config get <WORKING_DIRECTORY>` and `dotnet nuget config get <CONFIG_KEY>`. Any better ideas?
+3. `--working-dir` is changed from an argument into an option. Because we could not differentiate `dotnet nuget config get <WORKING_DIRECTORY>` and `dotnet nuget config get <CONFIG_KEY>`. Any better ideas?
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -133,7 +133,7 @@ Prints out a description of how to use the command.
 
 - --show-path
 
-Indicate that the NuGet configuration file path will be show besides the configuration settings.
+Indicate that the NuGet configuration file path will be shown besides the configuration settings.
 
 #### Examples
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -326,13 +326,15 @@ But we might need to change this behavior in the future.
 Considering this will be a breaking change, we will only consider doing it in main version change, if there are enough votes.
 
 ## Open Questions
-1. Shall we use `dotnet nuget config get all` or `dotnet nuget config get` to get all configuration settings?
+1. Shall we use `dotnet nuget config path` or `dotnet nuget config paths` to get all configuration file paths?
 
-2. `--working-dir` is changed from an argument into an option. (Follow the example of Dotnet store command. It has -w|--working-dir <WORKING_DIRECTORY> option https://learn.microsoft.com/dotnet/core/tools/dotnet-store#optional-options). Any other thoughts?
+2. Shall we use `dotnet nuget config get all` or `dotnet nuget config get` to get all configuration settings?
 
-3. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+3. `--working-dir` is changed from an argument into an option. (Follow the example of Dotnet store command. It has -w|--working-dir <WORKING_DIRECTORY> option https://learn.microsoft.com/dotnet/core/tools/dotnet-store#optional-options). Any other thoughts?
 
-4. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
+4. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+
+5. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
 ```
 packageSources:
   clear

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -31,17 +31,18 @@ List all the paths of NuGet configuration files that will be applied, when invok
 The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
 You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
+#### Arguments
 
-#### Options
+- WORKING_DIRECTORY
 
-- -w|--working-dir <WORKING_DIRECTORY>
+Run this command as if working directory is set to the specified directory. If it's not specified, the current working directory will be used.
 
-Run this command as if working directory is set to the specified directory.
-
-If the specified `--working-dir` doesn't exist, an error is displayed indicating the `--working-dir` doesn't exist.
+If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indicating the `WORKING_DIRECTORY` doesn't exist.
 
 > [!Note]
-> If `--working-dir` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+> If `WORKING_DIRECTORY` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+
+#### Options
 
 - -?|-h|--help
 
@@ -65,7 +66,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the paths of NuGet configuration files that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config path  --working-dir C:\Test\Repos
+dotnet nuget config path C:\Test\Repos
 
 C:\Test\Repos\NuGet.Config
 C:\Test\NuGet.Config
@@ -74,20 +75,20 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-- List all the NuGet configuration file that will be applied, but passing a non-exsiting `--working-dir`.
+- List all the NuGet configuration file that will be applied, but passing a non-existing argument `WORKING_DIRECTORY`.
 
 ```
-dotnet nuget config path  --working-dir C:\Test\NonExistingRepos
+dotnet nuget config path C:\Test\NonExistingRepos
 
 Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 ```
 
-- List all the NuGet configuration file that will be applied, but passing an inaccessible `--working-dir`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
+- List all the NuGet configuration file that will be applied, but passing an inaccessible `WORKING_DIRECTORY`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
 
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config path  --working-dir C:\Test\AccessibleRepos\NotAccessibleSolution
+dotnet nuget config path C:\Test\AccessibleRepos\NotAccessibleSolution
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config
@@ -104,7 +105,7 @@ Get the NuGet configuration settings that will be applied.
 
 - ALL
 
-Get all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
+Get all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the working directory path. 
 
 - CONFIG_KEY
 
@@ -112,19 +113,19 @@ Get the effective value of the specified configuration settings of the [config s
 
 
 > [!Note]
-> The CONFIG_KEY could only be one of the valid key in config section. 
+> The CONFIG_KEY could only be one of the valid keys in config section. 
 For other sections, like package source section, we have/will have specific command [dotnet nuget list source](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-list-source).
 
-#### Options
+- WORKING_DIRECTORY
 
-- -w|--working-dir <WORKING_DIRECTORY>
+Run this command as if working directory is set to the specified directory. If it's not specified, the current working directory will be used.
 
-Run this command as if working directory is set to the specified directory.
-
-If the specified `--working-dir` doesn't exist, an error is displayed indicating the `--working-dir` doesn't exist.
+If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indicating the `WORKING_DIRECTORY` doesn't exist.
 
 > [!Note]
-> If `--working-dir` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+> If `WORKING_DIRECTORY` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+
+#### Options
 
 - -?|-h|--help
 
@@ -161,7 +162,7 @@ packageRestore:
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config get all --working-dir C:\Test\Repos
+dotnet nuget config get all C:\Test\Repos
 
 packageSources:
   clear
@@ -233,7 +234,7 @@ Set the NuGet configuration settings.
 This command will set the value of a specified NuGet configuration setting.
 
 Please note this command only manages settings in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section).
-For other settings not in config section, we have/will have other dedicated commands. E.g. for [trustedSigners section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section), we have [dotnet nuget trust](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust) command.
+For other settings not in config section, we have/will have other dedicated commands. E.g., for [trustedSigners section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section), we have [dotnet nuget trust](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust) command.
 
 #### Arguments
 
@@ -328,13 +329,26 @@ Considering this will be a breaking change, we will only consider doing it in ma
 ## Open Questions
 1. Shall we use `dotnet nuget config path` or `dotnet nuget config paths` to get all configuration file paths?
 
+2. `WORKING_DIRECTORY` is changed from an option to an argument. So we have `dotnet nuget config path <WORKING_DIRECTORY>` and `dotnet nuget config get <ALL|CONFIG_KEY> <WORKING_DIRECTORY>`. Is it okey if we have two arguments in the second command? And if it's key, only the second argument could be optional, right? 
+
+3. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+
+
+## Considerations
+1. Will this command help with diagnosing incorrect setting format?
+<br />No. Incorrect NuGet settings should have separate error/warning message to tell the customer what's wrong in the setting file. If we have incorrect NuGet settings, all NuGet command, including `dotnet nuget config` command, should display the same error/warning message.
+<br />E.g., if we have an invalid XML problem in one of the NuGet configuration file, running all NuGet command will get an error as following:
+```
+dotnet nuget list source
+error: NuGet.Config is not valid XML. Path: 'C:\Users\username\Source\Repos\NuGet.Config'.
+error:   The 'disabledPackageSources' start tag on line 19 position 4 does not match the end tag of 'configuration'. Line 20, position 3.
+```
+
 2. Shall we use `dotnet nuget config get all` or `dotnet nuget config get` to get all configuration settings?
+<br />We will use `dotnet nuget config get all` to get all configuration settings, or else, we could not differentiate `dotnet nuget config get <CONFIG_KEY>` and `dotnet nuget config get <WORKING_DIRECTORY>`.
 
-3. `--working-dir` is changed from an argument into an option. (Follow the example of Dotnet store command. It has -w|--working-dir <WORKING_DIRECTORY> option https://learn.microsoft.com/dotnet/core/tools/dotnet-store#optional-options). Any other thoughts?
 
-4. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
-
-5. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
+3. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specific config key (which is aligned with NuGet config command). `dotnet nuget config get` will get all merged configuration settings(not XML format). Since many sections are not simple key-value pairs, we need to define the format of outputs when getting all merged configuration settings. We need to define formats for all kinds of config sections. Here is an example:
 ```
 packageSources:
   clear
@@ -349,14 +363,4 @@ packageSourceMapping:
 packageRestore:
   add key="enabled" value="False"
   add key="automatic" value="False"
-```
-
-## Considerations
-1. Will this command help with diagnosing incorrect setting format?
-<br />No. Incorrect NuGet settings should have seperate error/warning message to tell the customer what's wrong in the setting file. If we have incorrect NuGet settings, all NuGet command, including `dotnet nuget config` command, should display the same error/warning message.
-<br />E.g. if we have an invalid XML problem in one of the NuGet configuration file, running all NuGet command will get an error as following:
-```
-dotnet nuget list source
-error: NuGet.Config is not valid XML. Path: 'C:\Users\username\Source\Repos\NuGet.Config'.
-error:   The 'disabledPackageSources' start tag on line 19 position 4 does not match the end tag of 'configuration'. Line 20, position 3.
 ```

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -15,7 +15,7 @@ This feature is for dotnet.exe users.
 Design and implement `dotnet nuget config` command.
 
 ## Non-Goals
-Design and implement `dotnet nuget config` command with commands other than `list`, e.g. add/update/delete
+Design and implement in the same way for NuGet.exe command.
 
 ## Solution
 The following command will be implemented in the `dotnet.exe` CLI.
@@ -101,13 +101,13 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 
 Get the NuGet configuration settings that will be applied. 
 
-If CONFIG_KEY is not specified, this command will list all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
-
 #### Arguments
 
 - CONFIG_KEY
 
 Get the effective value of the specified configuration settings of the [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section). Please note this is the result of che 
+
+If CONFIG_KEY is not specified, this command will get all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
 
 > [!Note]
 > The CONFIG_KEY could only be one of the valid key in config section. 
@@ -336,16 +336,20 @@ dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppD
 ```
 
 ## Future Work
-1. The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
-2. We will discuss if adding this command into NuGet.exe CLI, in the future.
-3. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
+1. The `dotnet nuget config path/get` is a community ask. We will discuss if adding this command into NuGet.exe CLI, in the future.
+2. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. 
+But the behavior is confusing: the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file. We might need to change this behavior in the future. (Related code: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L229)
 
 ## Open Questions
 1. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
-2. What are the recommended verbs in dotnet command when setting and unsetting values?  ('set' and 'unset' work or not?)
-3. `Get` is not mentioned in this doc. It may cause some confusions:
-   Should `get` work for settings not in config section? (It's workable, but then we will miss `set` and `unset` for those as those are not doable)
-   Should `get` get the settings from a specific config file(like `set` and `unset`), or get the merged settings from multiple config files?
+
+2. `dotnet nuget config get <CONFIG_KEY>` will get the value of the specifc config key (which is aligned with NuGet config command). But
+`dotnet nuget config get` will get all merged configuration settings in xml format, since many sections are not simple key-value pairs.
+ Do we need to have another verb for getting all merged configuration settings? 
+
+3. `dotnet nuget config get -v d` will display source of each configuration setting key, in a format of comment in xml file. So that people can still redirect the output into a file without breaking any syntax. Does that sound good to you?
+
+3. `--working-directory` is changed from an argument into an option. Because we could not differentiate `dotnet nuget config get <WORKING_DIRECTORY>` and `dotnet nuget config get <CONFIG_KEY>`. Any better ideas?
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -326,7 +326,6 @@ Considering this will be a breaking change, we will only consider doing it in ma
 
 ## Open Questions
 
-1. `WORKING_DIRECTORY` is changed from an option to an argument. So we have `dotnet nuget config paths <WORKING_DIRECTORY>` and `dotnet nuget config get <ALL|CONFIG_KEY> <WORKING_DIRECTORY>`. Is it okey if we have two arguments in the second command? And if it's key, only the second argument could be optional, right? 
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?
@@ -364,3 +363,7 @@ packageRestore:
 
 5. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
 <br />`--show-path` is better. Verbosity is something to apply to logging, not so much the output of a command like this. Also in most cases of the .NET CLI, the verbosity doesn't do anything unless it's a command that ends up running MSBuild.
+
+
+6. `WORKING_DIRECTORY` is changed from an option to an argument. So we have `dotnet nuget config paths <WORKING_DIRECTORY>` and `dotnet nuget config get <ALL|CONFIG_KEY> <WORKING_DIRECTORY>`. Is it okey if we have two arguments in the second command? And if it's okey, only the second argument could be optional, right? 
+<br /> Confirmed with .NET sdk folks. There is no problem of having two arguments in the command and the second argument could be optional.

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -15,7 +15,7 @@ This feature is for dotnet.exe users.
 Design and implement `dotnet nuget config` command.
 
 ## Non-Goals
-Design and implement `dotnet nuget config` command with commands other than `list`, E.g. add/update/delete
+Design and implement `dotnet nuget config` command with commands other than `list`, e.g. add/update/delete
 
 ## Solution
 The following command will be implemented in the `dotnet.exe` CLI.
@@ -26,14 +26,21 @@ The following command will be implemented in the `dotnet.exe` CLI.
 
 - List
 
-Lists all the NuGet configuration file locations. This command will include all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path. The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
+Lists all the NuGet configuration file locations. 
+
+This command will include all the NuGet configuration file that will be applied, when invoking NuGet command from the current working directory path. The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
 You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
 #### Arguments
 
-- CURRENT_DIRECTORY
+- WORKING_DIRECTORY
 
-Run this command as if current directory is set to the specified directory.
+Run this command as if working directory is set to the specified directory.
+
+If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indicating the `WORKING_DIRECTORY` doesn't exist.
+
+> [!Note]
+> If `WORKING_DIRECTORY` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
 
 #### Options
 
@@ -68,17 +75,35 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
+- List all the NuGet configuration file that will be applied, but passing a non-exsiting `WORKING_DIRECTORY`.
+
+```
+dotnet nuget config list  C:\Test\NonExistingRepos
+
+Error: The path "C:\Test\NonExistingRepos" doesn't exist.
+```
+
+- List all the NuGet configuration file that will be applied, but passing an inaccessible `WORKING_DIRECTORY`: C:\Test\AccessibleRepos\NotAccessibleSolution. 
+
+The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
+
+```
+dotnet nuget config list  C:\Test\AccessibleRepos\NotAccessibleSolution
+
+C:\Test\AccessibleRepos\NuGet.Config
+C:\Test\NuGet.Config
+C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.config
+C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
+```
+
+
 ## Future Work
 1. The `dotnet nuget config list` is a community ask. We will consider adding more commands, like add/update/delete, in the future.
 2. We will discuss if adding this command into NuGet.exe CLI, in the future.
 3. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. But there is no `list` command. And the behavior is confusing (the `set` command will set the property which appears last when loading, so sometimes it's not updating the closest NuGet configuration file). Do we want to implement those subcommand(e.g.`set`) in the future in dotnet.exe differently?
 
 ## Open Questions
-1. When the specified `CURRENT_DIRECTORY` doesn't exist, shall we list user-wide and machine-wide config files? Or show a warning saying the working directory doesn't exist? Or do both?
-
-We decided to show a warning/error. 
-When user has a spelling mistake when passing `CURRENT_DIRECTORY` without knowing, if we don't show a warning/error, that would mislead the user.
-Showing them user-wide and machine-wide config files doesn't help.
 
 ## Considerations
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -24,7 +24,7 @@ The following command will be implemented in the `dotnet.exe` CLI.
 
 ### Commands
 
-### Path
+### Paths
 
 List all the paths of NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path.
 
@@ -53,7 +53,7 @@ Prints out a description of how to use the command.
 - List all the NuGet configuration file that will be applied, when invoking NuGet command in the current directory.
 
 ```
-dotnet nuget config path 
+dotnet nuget config paths 
 
 C:\Test\Repos\Solution\NuGet.Config
 C:\Test\Repos\NuGet.Config
@@ -66,7 +66,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the paths of NuGet configuration files that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config path C:\Test\Repos
+dotnet nuget config paths C:\Test\Repos
 
 C:\Test\Repos\NuGet.Config
 C:\Test\NuGet.Config
@@ -78,7 +78,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the NuGet configuration file that will be applied, but passing a non-existing argument `WORKING_DIRECTORY`.
 
 ```
-dotnet nuget config path C:\Test\NonExistingRepos
+dotnet nuget config paths C:\Test\NonExistingRepos
 
 Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 ```
@@ -88,7 +88,7 @@ Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config path C:\Test\AccessibleRepos\NotAccessibleSolution
+dotnet nuget config paths C:\Test\AccessibleRepos\NotAccessibleSolution
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config
@@ -131,11 +131,9 @@ If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indica
 
 Prints out a description of how to use the command.
 
-- -v|--verbosity <LEVEL>
+- --show-path
 
-Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
-
-When the verbosity level is detailed or diagnostic, the source(NuGet configuration file path) will be show besides the configuration settings.
+Indicate that the NuGet configuration file path will be show besides the configuration settings.
 
 #### Examples
 
@@ -183,7 +181,7 @@ packageRestore:
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the current directory. Show the source(nuget configuration file path) of each configuration settings/child items.
 
 ```
-dotnet nuget config get all -v d
+dotnet nuget config get all --show-path
 
 packageSources:
   add key="source1" value="https://test/source1/v3/index.json"     file: C:\Test\Repos\Solution\NuGet.Config
@@ -209,10 +207,10 @@ http://company-squid:3128@contoso.com"
 
 ```
 
-- Get `http_proxy` from config section, when invoking NuGet command in the current directory. Show the source(nuget configuration file path) of this configuration setting.
+- Get `http_proxy` from config section, when invoking NuGet command in the current directory. Show the nuget configuration file path of this configuration setting.
 
 ```
-dotnet nuget config get http_proxy 
+dotnet nuget config get http_proxy --show-path
 
 http://company-squid:3128@contoso.com"         file: C:\Test\Repos\Solution\NuGet.Config
 
@@ -318,7 +316,7 @@ dotnet nuget config unset defaultPushSource --configfile C:\Users\username\AppDa
 ```
 
 ## Future Work
-1. The `dotnet nuget config path/get` is a community ask. We will discuss if adding this command into NuGet.exe CLI, in the future.
+1. The `dotnet nuget config paths/get` is a community ask. We will discuss if adding this command into NuGet.exe CLI, in the future.
 
 2. NuGet.exe [config command](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-config) is implemented. 
 But the behavior is confusing: the `set` command will set the property which appears last when loading(for all writable files), so it's not updating the closest NuGet configuration file, but the user-wide NuGet configuration file.(Related code: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L229)
@@ -327,12 +325,8 @@ But we might need to change this behavior in the future.
 Considering this will be a breaking change, we will only consider doing it in main version change, if there are enough votes.
 
 ## Open Questions
-1. Shall we use `dotnet nuget config path` or `dotnet nuget config paths` to get all configuration file paths?
 
-2. `WORKING_DIRECTORY` is changed from an option to an argument. So we have `dotnet nuget config path <WORKING_DIRECTORY>` and `dotnet nuget config get <ALL|CONFIG_KEY> <WORKING_DIRECTORY>`. Is it okey if we have two arguments in the second command? And if it's key, only the second argument could be optional, right? 
-
-3. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
-
+1. `WORKING_DIRECTORY` is changed from an option to an argument. So we have `dotnet nuget config paths <WORKING_DIRECTORY>` and `dotnet nuget config get <ALL|CONFIG_KEY> <WORKING_DIRECTORY>`. Is it okey if we have two arguments in the second command? And if it's key, only the second argument could be optional, right? 
 
 ## Considerations
 1. Will this command help with diagnosing incorrect setting format?
@@ -364,3 +358,9 @@ packageRestore:
   add key="enabled" value="False"
   add key="automatic" value="False"
 ```
+
+4. Shall we use `dotnet nuget config path` or `dotnet nuget config paths` to get all configuration file paths?
+<br />Since it returns multiple paths, we will use `dotnet nuget config paths`.
+
+5. To show configuration files locations, is it better to use `--verbosity` option or some option named like `--show-path`? (git command is using `--show-origin` for similar purpose)
+<br />`--show-path` is better. Verbosity is something to apply to logging, not so much the output of a command like this. Also in most cases of the .NET CLI, the verbosity doesn't do anything unless it's a command that ends up running MSBuild.

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -31,18 +31,17 @@ List all the paths of NuGet configuration files that will be applied, when invok
 The listed NuGet configuration files are in priority order. So the order of loading those configurations is reversed, that is, loading order is from the bottom to the top. So the configuration on the top will apply.
 You may refer to [How settings are applied](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied) for more details. 
 
-#### Arguments
 
-- WORKING_DIRECTORY
+#### Options
+
+- --working-directory
 
 Run this command as if working directory is set to the specified directory.
 
-If the specified `WORKING_DIRECTORY` doesn't exist, an error is displayed indicating the `WORKING_DIRECTORY` doesn't exist.
+If the specified `--working-directory` doesn't exist, an error is displayed indicating the `--working-directory` doesn't exist.
 
 > [!Note]
-> If `WORKING_DIRECTORY` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
-
-#### Options
+> If `--working-directory` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
 
 - -?|-h|--help
 
@@ -66,7 +65,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the paths of NuGet configuration files that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config path  C:\Test\Repos
+dotnet nuget config path  --working-directory C:\Test\Repos
 
 C:\Test\Repos\NuGet.Config
 C:\Test\NuGet.Config
@@ -78,7 +77,7 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 - List all the NuGet configuration file that will be applied, but passing a non-exsiting `WORKING_DIRECTORY`.
 
 ```
-dotnet nuget config path  C:\Test\NonExistingRepos
+dotnet nuget config path  --working-directory C:\Test\NonExistingRepos
 
 Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 ```
@@ -88,7 +87,7 @@ Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config list  C:\Test\AccessibleRepos\NotAccessibleSolution
+dotnet nuget config list  --working-directory C:\Test\AccessibleRepos\NotAccessibleSolution
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config
@@ -100,9 +99,141 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 #### Commands
 - Get
 
-Get the list of all the NuGet configuration settings. 
+Get the NuGet configuration settings that will be applied. 
 
-This command will list merged NuGet configuration settings from one or multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
+If CONFIG_KEY is not specified, this command will list all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
+
+#### Arguments
+
+- CONFIG_KEY
+
+Get the effective value of the specified configuration settings of the [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section). Please note this is the result of che 
+
+> [!Note]
+> The CONFIG_KEY could only be one of the valid key in config section. 
+For other sections, like package source section, we have/will have specific command [dotnet nuget list source](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-list-source).
+
+#### Options
+
+- --working-directory
+
+Run this command as if working directory is set to the specified directory.
+
+If the specified `--working-directory` doesn't exist, an error is displayed indicating the `--working-directory` doesn't exist.
+
+> [!Note]
+> If `--working-directory` (or its parent directories) is not accessible, the command will ignore any NuGet configuration files under those directories without any warning/error. This is aligned with other NuGet commands.
+
+- -?|-h|--help
+
+Prints out a description of how to use the command.
+
+- -v|--verbosity <LEVEL>
+
+Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
+
+When the verbosity level is detailed or diagnostic, the source(NuGet configuration file path) will be show besides the configuration settings.
+
+#### Examples
+
+- Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the current directory.
+
+```
+dotnet nuget config get
+
+<configuration>
+  <packageSources>
+    <add key="source1" value="https://test/source1/v3/index.json" />
+    <add key="source2" value="https://test/source2/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key = "source1">
+      <package pattern="microsoft.*" />
+      <package pattern="nuget.*" />
+    </packageSource>
+    <packageSource key = "source2">
+      <package pattern="system.*" />
+    </packageSource>
+  </packageSourceMapping>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+</configuration>
+
+```
+- Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the specific directory.
+
+```
+dotnet nuget config get --working-directory C:\Test\Repos
+
+<configuration>
+  <packageSources>
+    <add key="source1" value="https://test/source1/v3/index.json" />
+    <add key="source2" value="https://test/source2/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key = "source1">
+      <package pattern="microsoft.*" />
+      <package pattern="nuget.*" />
+    </packageSource>
+    <packageSource key = "source2">
+      <package pattern="system.*" />
+    </packageSource>
+  </packageSourceMapping>
+  <packageRestore>
+    <add key="enabled" value="False" />
+    <add key="automatic" value="False" />
+  </packageRestore>
+</configuration>
+
+```
+
+- Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the current directory. Show the source(nuget configuration file path) of each configuration settings/child items.
+
+```
+dotnet nuget config get -v d
+
+<configuration>
+  <packageSources>
+    <add key="source1" value="https://test/source1/v3/index.json" />   <!-- file: C:\Test\Repos\Solution\NuGet.Config -->
+    <add key="source2" value="https://test/source2/v3/index.json" />   <!-- file: C:\Test\Repos\NuGet.Config -->
+  </packageSources>
+  <packageSourceMapping>
+    <clear />                                 <!-- file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config -->
+    <packageSource key = "source1">           <!-- file: C:\Test\Repos\Solution\NuGet.Config -->
+      <package pattern="microsoft.*" />
+      <package pattern="nuget.*" />
+    </packageSource>
+    <packageSource key = "source2">           <!-- file: C:\Test\Repos\NuGet.Config -->
+      <package pattern="system.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+
+```
+
+- Get `http_proxy` from config section, when invoking NuGet command in the current directory.
+
+```
+dotnet nuget config get http_proxy 
+
+http://company-squid:3128@contoso.com"
+
+```
+
+- Get `http_proxy` from config section, when `http_proxy` is not set in any of the NuGet configuration files.
+
+```
+dotnet nuget config get http_proxy 
+
+Key 'http_proxy' not found.
+
+```
+
+#### Commands
 
 - Set
 
@@ -111,29 +242,25 @@ Set the NuGet configuration settings.
 This command will set the value of a specified NuGet configuration setting.
 
 Please note this command only manages settings in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section).
-For other settings not in config section, we have/will have other commands. E.g. for [trustedSigners section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section), we have [dotnet nuget trust](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust) command.
+For other settings not in config section, we have/will have other dedicated commands. E.g. for [trustedSigners section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section), we have [dotnet nuget trust](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust) command.
 
 #### Arguments
 
-- SETTING_KEY
+- CONFIG_KEY
 
 Specify the key of the settings that are to be set.
 
-If the specified `SETTING_KEY` is not a key in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section), an error is displayed indicating the `SETTING_KEY` could not be set.
+If the specified `CONFIG_KEY` is not a key in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section), a message is displayed indicating the `CONFIG_KEY` could not be set.
 
-- SETTING_VALUE
+- CONFIG_VALUE
 
-Set the value of the SETTING_KEY to SETTING_VALUE.
+Set the value of the CONFIG_KEY to CONFIG_VALUE.
 
 #### Options
+
 - --config-file
 
-Specify the config file path to add the setting key-value pair. If it's not specified, the config file with highest priority will be updated.
-
-- -v|--verbosity <LEVEL>
-
-Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal. 
-When the verbosity level is detailed or diagnostic, 
+Specify the config file path to add the setting key-value pair. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
 
 - -?|-h|--help
 
@@ -155,6 +282,8 @@ dotnet nuget config set defaultPushSource https://MyRepo/ES/api/v2/package --con
 
 ```
 
+#### Commands
+
 - Unset
 
 Remove the NuGet configuration settings. 
@@ -166,12 +295,11 @@ For other settings not in config section, we have/will have other commands. E.g.
 
 #### Arguments
 
-- SETTING_KEY
+- CONFIG_KEY
 
 Specify the key of the settings that are to be removed.
 
-If the specified `SETTING_KEY` is not a key in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section), an error is displayed indicating the `SETTING_KEY` could not be set.
-
+If the specified `CONFIG_KEY` is not a key in [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section), a message is displayed indicating the `CONFIG_KEY` could not be unset.
 
 #### Options
 
@@ -183,9 +311,17 @@ Specify the config file path to remove the setting key-value pair. If it's not s
 
 Prints out a description of how to use the command.
 
+- --config-file
+
+Specify the config file path to remove the setting key-value pair. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
+
+- -?|-h|--help
+
+Prints out a description of how to use the command.
+
 #### Examples
 
-- Unset the `signatureValidationMode` in the closest NuGet configuration file.
+- Unset the `signatureValidationMode` in the user-wide NuGet configuration file.
 
 ```
 dotnet nuget config unset signatureValidationMode
@@ -196,32 +332,6 @@ dotnet nuget config unset signatureValidationMode
 
 ```
 dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
-
-```
-
-- List only the NuGet configuration settings, when invoking NuGet command in the specific directory.
-
-```
-dotnet nuget config list  C:\Test\Repos
-
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Microsoft Visual Studio Offline Packages" value="C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\" />
-    <add key="Test Package source" value="C:\work" />
-  </packageSources>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-  <bindingRedirects>
-    <add key="skip" value="False" />
-  </bindingRedirects>
-  <packageManagement>
-    <add key="format" value="0" />
-    <add key="disabled" value="False" />
-  </packageManagement>
-</configuration>
 
 ```
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -76,9 +76,9 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ## Open Questions
 1. When the specified `CURRENT_DIRECTORY` doesn't exist, shall we list user-wide and machine-wide config files? Or show a warning saying the working directory doesn't exist? Or do both?
 
-I prefer do just a warning, or do both. 
-When user has a spelling mistake when passing `CURRENT_DIRECTORY` without knowing, if we don't show a warning, that would mislead the user.
-Showing them user-wide and machine-wide config files could provide extra info and may help them to understand the example of a right path. But since this is not a real scenario (It's impossible that a real `CURRENT_DIRECTORY` doesn't exist), this adds very limited value.
+We decided to show a warning/error. 
+When user has a spelling mistake when passing `CURRENT_DIRECTORY` without knowing, if we don't show a warning/error, that would mislead the user.
+Showing them user-wide and machine-wide config files doesn't help.
 
 ## Considerations
 

--- a/proposed/2022/dotnet-nuget-config-spec.md
+++ b/proposed/2022/dotnet-nuget-config-spec.md
@@ -22,9 +22,9 @@ The following command will be implemented in the `dotnet.exe` CLI.
 
 ### `dotnet nuget config`
 
-#### Commands
+### Commands
 
-- Path
+### Path
 
 List all the paths of NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path.
 
@@ -87,7 +87,7 @@ Error: The path "C:\Test\NonExistingRepos" doesn't exist.
 The configuration file under C:\Test\AccessibleRepos\NotAccessibleSolution\NuGet.Config will be ignored without any warning or error.
 
 ```
-dotnet nuget config list  --working-dir C:\Test\AccessibleRepos\NotAccessibleSolution
+dotnet nuget config path  --working-dir C:\Test\AccessibleRepos\NotAccessibleSolution
 
 C:\Test\AccessibleRepos\NuGet.Config
 C:\Test\NuGet.Config
@@ -96,18 +96,20 @@ C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.FallbackLocation.conf
 C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
 ```
 
-#### Commands
-- Get
+### Get
 
 Get the NuGet configuration settings that will be applied. 
 
 #### Arguments
 
+- ALL
+
+Get all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
+
 - CONFIG_KEY
 
-Get the effective value of the specified configuration settings of the [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section). Please note this is the result of che 
+Get the effective value of the specified configuration settings of the [config section](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#config-section). 
 
-If CONFIG_KEY is not specified, this command will get all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the current working directory path. 
 
 > [!Note]
 > The CONFIG_KEY could only be one of the valid key in config section. 
@@ -139,79 +141,68 @@ When the verbosity level is detailed or diagnostic, the source(NuGet configurati
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the current directory.
 
 ```
-dotnet nuget config get
+dotnet nuget config get all
 
-<configuration>
-  <packageSources>
-    <add key="source1" value="https://test/source1/v3/index.json" />
-    <add key="source2" value="https://test/source2/v3/index.json" />
-  </packageSources>
-  <packageSourceMapping>
-    <clear />
-    <packageSource key = "source1">
-      <package pattern="microsoft.*" />
-      <package pattern="nuget.*" />
-    </packageSource>
-    <packageSource key = "source2">
-      <package pattern="system.*" />
-    </packageSource>
-  </packageSourceMapping>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-</configuration>
+packageSources:
+  "source1" value="https://test/source1/v3/index.json"
+  "source2" value="https://test/source2/v3/index.json"
+
+packageSourceMapping:
+  clear
+  "source1" 
+    pattern="microsoft.*"
+    pattern="nuget.*"
+  "source2" 
+    pattern="system.*"
+
+packageRestore:
+  "enabled" value="False"
+  "automatic" value="False"
 
 ```
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the specific directory.
 
 ```
-dotnet nuget config get --working-dir C:\Test\Repos
+dotnet nuget config get all --working-dir C:\Test\Repos
 
-<configuration>
-  <packageSources>
-    <add key="source1" value="https://test/source1/v3/index.json" />
-    <add key="source2" value="https://test/source2/v3/index.json" />
-  </packageSources>
-  <packageSourceMapping>
-    <clear />
-    <packageSource key = "source1">
-      <package pattern="microsoft.*" />
-      <package pattern="nuget.*" />
-    </packageSource>
-    <packageSource key = "source2">
-      <package pattern="system.*" />
-    </packageSource>
-  </packageSourceMapping>
-  <packageRestore>
-    <add key="enabled" value="False" />
-    <add key="automatic" value="False" />
-  </packageRestore>
-</configuration>
+packageSources:
+  "source1" value="https://test/source1/v3/index.json"
+  "source2" value="https://test/source2/v3/index.json"
+
+packageSourceMapping:
+  clear
+  "source1" 
+    pattern="microsoft.*"
+    pattern="nuget.*"
+  "source2" 
+    pattern="system.*"
+
+packageRestore:
+  "enabled" value="False"
+  "automatic" value="False"
 
 ```
 
 - Get all the NuGet configuration settings that will be applied, when invoking NuGet command in the current directory. Show the source(nuget configuration file path) of each configuration settings/child items.
 
 ```
-dotnet nuget config get -v d
+dotnet nuget config get all -v d
 
-<configuration>
-  <packageSources>
-    <add key="source1" value="https://test/source1/v3/index.json" />   <!-- file: C:\Test\Repos\Solution\NuGet.Config -->
-    <add key="source2" value="https://test/source2/v3/index.json" />   <!-- file: C:\Test\Repos\NuGet.Config -->
-  </packageSources>
-  <packageSourceMapping>
-    <clear />                                 <!-- file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config -->
-    <packageSource key = "source1">           <!-- file: C:\Test\Repos\Solution\NuGet.Config -->
-      <package pattern="microsoft.*" />
-      <package pattern="nuget.*" />
-    </packageSource>
-    <packageSource key = "source2">           <!-- file: C:\Test\Repos\NuGet.Config -->
-      <package pattern="system.*" />
-    </packageSource>
-  </packageSourceMapping>
-</configuration>
+packageSources:
+  "source1" value="https://test/source1/v3/index.json"     file: C:\Test\Repos\Solution\NuGet.Config
+  "source2" value="https://test/source2/v3/index.json"     file: C:\Test\Repos\NuGet.Config
+
+packageSourceMapping:
+  clear                                                   file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+  "source1"                                               file: C:\Test\Repos\Solution\NuGet.Config
+    pattern="microsoft.*"
+    pattern="nuget.*"
+  "source2" 
+    pattern="system.*"                                    file: C:\Test\Repos\NuGet.Config
+
+packageRestore:
+  "enabled" value="False"                                 file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+  "automatic" value="False"                               file: C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 
 ```
 
@@ -224,6 +215,15 @@ http://company-squid:3128@contoso.com"
 
 ```
 
+- Get `http_proxy` from config section, when invoking NuGet command in the current directory. Show the source(nuget configuration file path) of this configuration setting.
+
+```
+dotnet nuget config get http_proxy 
+
+http://company-squid:3128@contoso.com"         file: C:\Test\Repos\Solution\NuGet.Config
+
+```
+
 - Get `http_proxy` from config section, when `http_proxy` is not set in any of the NuGet configuration files.
 
 ```
@@ -233,9 +233,7 @@ Key 'http_proxy' not found.
 
 ```
 
-#### Commands
-
-- Set
+### Set
 
 Set the NuGet configuration settings. 
 
@@ -258,9 +256,9 @@ Set the value of the CONFIG_KEY to CONFIG_VALUE.
 
 #### Options
 
-- --config-file
+- --configfile <FILE>
 
-Specify the config file path to add the setting key-value pair. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
+The NuGet configuration file (nuget.config) to use. If specified, only the settings from this file will be used. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
 
 - -?|-h|--help
 
@@ -278,13 +276,11 @@ dotnet nuget config set signatureValidationMode require
 - Set the `defaultPushSource` in the specified NuGet configuration file.
 
 ```
-dotnet nuget config set defaultPushSource https://MyRepo/ES/api/v2/package --config-file C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+dotnet nuget config set defaultPushSource https://MyRepo/ES/api/v2/package --configfile C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 
 ```
 
-#### Commands
-
-- Unset
+### Unset
 
 Remove the NuGet configuration settings. 
 
@@ -303,9 +299,9 @@ If the specified `CONFIG_KEY` is not a key in [config section](https://learn.mic
 
 #### Options
 
-- --config-file
+- --configfile <FILE>
 
-Specify the config file path to remove the setting key-value pair. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
+The NuGet configuration file (nuget.config) to use. If specified, only the settings from this file will be used. If it's not specified, `%AppData%\NuGet\NuGet.Config` (Windows), or `~/.nuget/NuGet/NuGet.Config` or `~/.config/NuGet/NuGet.Config` (Mac/Linux) is used. See [On Mac/Linux, the user-level config file location varies by tooling.](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#on-maclinux-the-user-level-config-file-location-varies-by-tooling)
 
 - -?|-h|--help
 
@@ -323,7 +319,7 @@ dotnet nuget config unset signatureValidationMode
 - Unset the `defaultPushSource` in the specified NuGet configuration file.
 
 ```
-dotnet nuget config unset defaultPushSource --config-file C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
+dotnet nuget config unset defaultPushSource --configfile C:\Users\username\AppData\Roaming\NuGet\NuGet.Config
 
 ```
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/12297
Add a spec of `dotnet nuget config list` command.

It's a part of epic issue:
 Add a dotnet nuget config command https://github.com/NuGet/Home/issues/12296

