### PR TITLE
Update the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: "[Bug]: "
 labels: ["Type:Bug", "Triage:Untriaged"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/DCR.yml
+++ b/.github/ISSUE_TEMPLATE/DCR.yml
@@ -1,6 +1,5 @@
 name: Behavior Change
 description: When you want NuGet to work differently than it does.
-title: "[DCR]: "
 labels: ["Type:DCR", "Triage:Untriaged"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: "When you want a new feature for something that doesn't already exist"
-title: "[Feature]: "
 labels: ["Type:Feature", "Triage:Untriaged"]
 body:
   - type: markdown


### PR DESCRIPTION
The issue templates currently have a title that says `bug`, `dcr`, `feature` etc. 

I think this is redundant as we use labels for that. 

Sometimes, the issue title isn't really what the issue is exactly about.
Other times an issue "evolves" as we get clarity. 