### PR TITLE
Add a bot to Close stale icebox issues, with internal-debugging label

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1575,6 +1575,488 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              3,
+              7,
+              11,
+              15,
+              19,
+              23
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status:Inactive"
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Status:Excluded from icebox cleanup"
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Triage:NeedsTriageDiscussion"
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Icebox cleanup candidate"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "internal-debugging"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Icebox cleanup candidate"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Due to lack of recent activity, this issue has been marked as a candidate for icebox cleanup. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will add a `Triage:NeedsTriageDiscussion` label and lead to a triaging process.\nThis process is part of the experimental [Stale icebox issues cleanup](https://github.com/NuGet/Home/issues/12113) we are currently trialing. Please share any feedback you might have in the linked issue.\n"
+            }
+          }
+        ],
+        "taskName": "[Close stale icebox][4-1] Search \"Status:Inactive\" but without \"Status:Excluded from icebox cleanup\" and \"Triage:NeedsTriageDiscussion\", add \"Icebox cleanup candidate\" and show a warning."
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Icebox cleanup candidate"
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "Triage:NeedsTriageDiscussion"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 14
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "internal-debugging"
+            }
+          }
+        ],
+        "taskName": "[Close stale icebox][4-2] Close \"Icebox cleanup candidate\" if no activity within 14 days.",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue will now be closed since it had been marked Icebox cleanup candidate, but received no further activity in the past 14 days. It is still possible to reopen or comment on the issue, but please note that the issue will be locked if it remains inactive for another 30 days."
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Icebox cleanup candidate"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "Triage:NeedsTriageDiscussion"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "internal-debugging"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Close stale icebox][4-3] For \"Icebox cleanup candidate\" issues, if there is any comments, add \"Triage:NeedsTriageDiscussion\" label",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Triage:NeedsTriageDiscussion"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              6,
+              10,
+              14,
+              18,
+              22
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isClosed",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Icebox cleanup candidate"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 30
+            }
+          },
+          {
+            "name": "isUnlocked",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "internal-debugging"
+            }
+          }
+        ],
+        "taskName": "[Close stale icebox][4-4] For closed \"Icebox cleanup candidate\" issues, lock them after 30 days.",
+        "actions": [
+          {
+            "name": "lockIssue",
+            "parameters": {}
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1722,7 +1722,7 @@
             }
           }
         ],
-        "taskName": "[Close stale icebox][4-1] Search \"Status:Inactive\" but without \"Status:Excluded from icebox cleanup\" and \"Triage:NeedsTriageDiscussion\", add \"Icebox cleanup candidate\" and show a warning."
+        "taskName": "[Close stale icebox][3-1] Search \"Status:Inactive\" but without \"Status:Excluded from icebox cleanup\" and \"Triage:NeedsTriageDiscussion\", add \"Icebox cleanup candidate\" and show a warning."
       }
     },
     {
@@ -1851,12 +1851,12 @@
             }
           }
         ],
-        "taskName": "[Close stale icebox][4-2] Close \"Icebox cleanup candidate\" if no activity within 14 days.",
+        "taskName": "[Close stale icebox][3-2] Close \"Icebox cleanup candidate\" if no activity within 14 days.",
         "actions": [
           {
             "name": "addReply",
             "parameters": {
-              "comment": "This issue will now be closed since it had been marked Icebox cleanup candidate, but received no further activity in the past 14 days. It is still possible to reopen or comment on the issue, but please note that the issue will be locked if it remains inactive for another 30 days."
+              "comment": "This issue will now be closed since it had been marked Icebox cleanup candidate, but received no further activity in the past 14 days. "
             }
           },
           {
@@ -1914,146 +1914,13 @@
         "eventNames": [
           "issue_comment"
         ],
-        "taskName": "[Close stale icebox][4-3] For \"Icebox cleanup candidate\" issues, if there is any comments, add \"Triage:NeedsTriageDiscussion\" label",
+        "taskName": "[Close stale icebox][3-3] For \"Icebox cleanup candidate\" issues, if there is any comments, add \"Triage:NeedsTriageDiscussion\" label",
         "actions": [
           {
             "name": "addLabel",
             "parameters": {
               "label": "Triage:NeedsTriageDiscussion"
             }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "scheduled",
-      "capabilityId": "ScheduledSearch",
-      "subCapability": "ScheduledSearch",
-      "version": "1.1",
-      "config": {
-        "frequency": [
-          {
-            "weekDay": 0,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 1,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 2,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 3,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 4,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 5,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          },
-          {
-            "weekDay": 6,
-            "hours": [
-              2,
-              6,
-              10,
-              14,
-              18,
-              22
-            ],
-            "timezoneOffset": -7
-          }
-        ],
-        "searchTerms": [
-          {
-            "name": "isClosed",
-            "parameters": {}
-          },
-          {
-            "name": "isIssue",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "Icebox cleanup candidate"
-            }
-          },
-          {
-            "name": "noActivitySince",
-            "parameters": {
-              "days": 30
-            }
-          },
-          {
-            "name": "isUnlocked",
-            "parameters": {}
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "internal-debugging"
-            }
-          }
-        ],
-        "taskName": "[Close stale icebox][4-4] For closed \"Icebox cleanup candidate\" issues, lock them after 30 days.",
-        "actions": [
-          {
-            "name": "lockIssue",
-            "parameters": {}
           }
         ]
       }


### PR DESCRIPTION
This is the first step for https://github.com/NuGet/Client.Engineering/issues/1784
The added rulesets are tested in bot-testing repo(but with different waiting time, to shorten the testing period). 
You may check the 1-4 rulesets of bot-testing repo in UI at: https://portal.fabricbot.ms/bot/   and enter "NuGet/bot-testing" and load config.

The testing example is: https://github.com/NuGet/bot-testing/issues/22
1. The searching tasks will check issues with `Status:Inactive` and `internal-debugging`, but without `Status:Excluded from icebox cleanup`, `Triage:NeedsTriageDiscussion`, `Icebox cleanup candidate`, to add label `Icebox cleanup candidate`, and a [comment ](https://github.com/NuGet/bot-testing/issues/22#issuecomment-1300463845)
2. After 14 days, if there is no activity on issues with `Icebox cleanup candidate` and `internal-debugging`, and without `Triage:NeedsTriageDiscussion`, the issue will be closed, and a comment "This issue will now be closed since it had been marked Icebox cleanup candidate, but received no further activity in the past 14 days.".
3. During the 14 days, if there is any comment on the issue, a `Triage:NeedsTriageDiscussion` label will be added. So it won't be closed anymore, until we manually remove the `Triage:NeedsTriageDiscussion` label. And this label will lead to a discussion in triaging meeting.

Note: the `internal-debugging` label is to narrow down the affected issues for the first step, just in case if we find anything wrong.