### PR TITLE
Update a bot to Close stale icebox issues, remove internal-debugging label

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1700,12 +1700,6 @@
             "parameters": {
               "label": "Icebox cleanup candidate"
             }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "internal-debugging"
-            }
           }
         ],
         "actions": [
@@ -1843,12 +1837,6 @@
             "parameters": {
               "days": 14
             }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "internal-debugging"
-            }
           }
         ],
         "taskName": "[Close stale icebox][3-2] Close \"Icebox cleanup candidate\" if no activity within 14 days.",
@@ -1901,12 +1889,6 @@
                   }
                 }
               ]
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "internal-debugging"
-              }
             }
           ]
         },


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/1784

This is the second step for https://github.com/NuGet/Client.Engineering/issues/1784

The testing on the following 4 issues with "internal-debugging" label looks good:
https://github.com/NuGet/Home/issues?q=is%3Aopen+is%3Aissue+label%3Ainternal-debugging

https://github.com/NuGet/Home/issues/8928 and https://github.com/NuGet/Home/issues/8515 with `Status:Excluded from icebox cleanup` label are not affected at all.

https://github.com/NuGet/Home/issues/8997 and  https://github.com/NuGet/Home/issues/8265 with `Status:Inactive` label and without `Status:Excluded from icebox cleanup` label are identified as `Icebox cleanup candidate` and a [comment ](https://github.com/NuGet/Home/issues/8265#issuecomment-1317433396) is added.
After adding some comment, the `Triage:NeedsTriageDiscussion` is added.