### PR TITLE
Update "vulnerabilities in restore" spec

### DIFF
--- a/proposed/2022/vulnerabilities-in-restore.md
+++ b/proposed/2022/vulnerabilities-in-restore.md
@@ -146,7 +146,10 @@ Periodically, the small file's data can be merged into the large file(s), and th
 
 - The vulnerability resource **must** be an array of objects.
 - Each object **must** contain:
-  - `@name`, a user friendly name for the page, **must** be unique.
+  - `@name`, a short name for the page, used for caching, and has a few restrictions:
+    - **must** be unique.
+    - **must** be between 1 and 32 characters long.
+    - **must** only contain  characters `A` to `Z`, `a` to `z`, `0` to `9`, or be `-` or `_`.
   - `@id`, the url that contains the data.
   - `@updated`, a UTC timestamp when the content at `@id` was updated last.
   - `comment`, a user friendly description.

--- a/proposed/2022/vulnerabilities-in-restore.md
+++ b/proposed/2022/vulnerabilities-in-restore.md
@@ -132,7 +132,7 @@ Both of these can be achieved by adding a means to understand whether a source s
 ```json
     {
       "@id": "https://nikolchevulntest.blob.core.windows.net/newcontainer/vulnerabilityindex.json",
-      "@type": "VulnerabilityInfo/6.6.0",
+      "@type": "VulnerabilityInfo/6.7.0",
       "comment": "The endpoint for discovering information about vulnerabilities of packages in this package source."
     },
 ```
@@ -358,7 +358,7 @@ For example, an Azure Artifacts source could have this in their index.json:
 
   {
     "@id": "https://api.nuget.org/v3/vulnerability.json",
-    "@type": "VulnerabilityInfo/6.6.0",
+    "@type": "VulnerabilityInfo/6.7.0",
     "comment": "The base data for vulnerability update periodically"
   }
   ]


### PR DESCRIPTION
* Add restrictions to `@name` element in the vulnerability index's page definition.

This minimizes risk that a malicious payload can harm clients

* Change the client version yo 6.7.0 in the service index.

NuGet didn't implement this in time for 6.6.0.
