### PR TITLE
Make the Doc Page URL a text input

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCS.yml
+++ b/.github/ISSUE_TEMPLATE/DOCS.yml
@@ -3,7 +3,7 @@ description: Report an issue with the NuGet Client documentation
 labels: ["Type:Docs", "Triage:Untriaged"]
 
 body:
-  - type: markdown
+  - type: input
     attributes:
       value: |
         **Docs Page URL**
@@ -13,7 +13,7 @@ body:
     id: description
     attributes:
       label: Description of the Issue
-      description: A clear and concise description of what the issue is.
+      description: A clear and concise description of the issue.
       placeholder: Describe the issue...
 
   - type: textarea


### PR DESCRIPTION
Make the Doc Page URL a text input.
Fixing this issue:
![image](https://github.com/user-attachments/assets/f70409eb-6476-4ad0-a2a2-402b108de62f)


