### PR TITLE
Untitled

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -1,0 +1,26 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Add a new MsBuild task to check for invalid projects without NuGet.targets -->
+  <Target Name="CheckForInvalidProjectsWithoutNuGetTargets" Condition=" '$(RestoreUseSkipNonexistentTargets)' == 'true' ">
+    <ItemGroup>
+      <InvalidProjects Include="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)" Condition="!Exists('%(Identity)')">
+        <Message Importance="high" Text="Warning: Project '%(Identity)' does not contain NuGet.targets and will be skipped during restore." />
+      </InvalidProjects>
+    </ItemGroup>
+  </Target>
+
+  <!-- Update the existing MsBuild task to include the new task for static graph restore -->
+  <Target Name="StaticGraphRestore" DependsOnTargets="CheckForInvalidProjectsWithoutNuGetTargets">
+    <MsBuild Condition=" '$(RestoreUseSkipNonexistentTargets)' == 'true' "
+        BuildInParallel="$(RestoreBuildInParallel)"
+        Projects="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)"
+        Targets="_IsProjectRestoreSupported"
+        SkipNonexistentTargets="true"
+        Properties="$(_GenerateRestoreGraphProjectEntryInputProperties)">
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="FilteredRestoreGraphProjectInputItems" />
+    </MsBuild>
+  </Target>
+
+</Project>


### PR DESCRIPTION
Fixes #9300

Add a warning for invalid projects without `NuGet.targets` in static graph restore.

* Add a new MsBuild task `CheckForInvalidProjectsWithoutNuGetTargets` to check for invalid projects without `NuGet.targets`.
* Update the existing MsBuild task `StaticGraphRestore` to include the new task for static graph restore.
* Add a condition to the new task to check for `$(RestoreUseSkipNonexistentTargets)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NuGet/Home/pull/14225?shareId=7162b6b3-1d84-4127-b110-932c4787ba70).