### PR TITLE
Stalebot: activity no longer adds `Triage:NeedsTriageDiscussion` & Now removes `Icebox cleanup candidate` & `Status:Inactive`

### DIFF
--- a/.github/policies/30-issue-stale-p3-cleanup.yml
+++ b/.github/policies/30-issue-stale-p3-cleanup.yml
@@ -67,6 +67,8 @@ configuration:
       if:
       - payloadType: Issue_Comment
       - isOpen
+      - isAction:
+          action: Created
       - hasLabel:
           label: Icebox cleanup candidate
       then:

--- a/.github/policies/30-issue-stale-p3-cleanup.yml
+++ b/.github/policies/30-issue-stale-p3-cleanup.yml
@@ -49,19 +49,30 @@ configuration:
           reply: 'This issue will now be closed since it had been marked Icebox cleanup candidate, but received no further activity in the past 14 days. '
       - closeIssue
     eventResponderTasks:
-    - description: '[30-30] Add "Triage:NeedsTriageDiscussion" when icebox cleanup candidate receives a comment'
+    - description: '[30-40] Remove "Icebox cleanup candidate" on issue activity'
+      if:
+      - payloadType: Issues
+      - isOpen
+      - not:
+          isAction:
+            action: Closed
+      - hasLabel:
+          label: Icebox cleanup candidate
+      then:
+      - removeLabel:
+          label: Icebox cleanup candidate
+      - removeLabel:
+          label: Status:Inactive
+    - description: '[30-50] Remove "Icebox cleanup candidate" on issue comment'
       if:
       - payloadType: Issue_Comment
       - isOpen
-      - isAction:
-          action: Created
       - hasLabel:
           label: Icebox cleanup candidate
-      - not:
-          hasLabel:
-            label: Triage:NeedsTriageDiscussion
       then:
-      - addLabel:
-          label: Triage:NeedsTriageDiscussion
+      - removeLabel:
+          label: Icebox cleanup candidate
+      - removeLabel:
+          label: Status:Inactive
 onFailure: 
 onSuccess: 

--- a/.github/policies/30-issue-stale-p3-cleanup.yml
+++ b/.github/policies/30-issue-stale-p3-cleanup.yml
@@ -49,21 +49,7 @@ configuration:
           reply: 'This issue will now be closed since it had been marked Icebox cleanup candidate, but received no further activity in the past 14 days. '
       - closeIssue
     eventResponderTasks:
-    - description: '[30-40] Remove "Icebox cleanup candidate" on issue activity'
-      if:
-      - payloadType: Issues
-      - isOpen
-      - not:
-          isAction:
-            action: Closed
-      - hasLabel:
-          label: Icebox cleanup candidate
-      then:
-      - removeLabel:
-          label: Icebox cleanup candidate
-      - removeLabel:
-          label: Status:Inactive
-    - description: '[30-50] Remove "Icebox cleanup candidate" on issue comment'
+    - description: '[30-40] Remove "Icebox cleanup candidate" on community comment'
       if:
       - payloadType: Issue_Comment
       - isOpen
@@ -71,6 +57,9 @@ configuration:
           action: Created
       - hasLabel:
           label: Icebox cleanup candidate
+      - not:
+          activitySenderHasPermission:
+            permission: Write
       then:
       - removeLabel:
           label: Icebox cleanup candidate


### PR DESCRIPTION
This change adds two event responder rules to ensure issues marked `Icebox cleanup candidate` and `Status:Inactive` are un-tagged when there is activity. 

- Removed [30-30] We don't need to ping Triage for discussion just because there's activity. Instead, the following new rules will remove the inactive flags:

- Added [30-40] which will only run on Created events for Community member Comments (not Edited or Deleted). 

Validated in bot-testing that labelling and commenting (by me, a repo-owner) is not considered a reason to remove the Inactive or Icebox labels:
<img width="924" height="275" alt="image" src="https://github.com/user-attachments/assets/1b80dab3-543c-46fb-88e5-31882ffaffcf" />

