### PR TITLE
Stalebot targets stale P3 Issues with fewest reactions first (up to 5 max)

### DIFF
--- a/.github/workflows/stale-p3-search.yml
+++ b/.github/workflows/stale-p3-search.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Mark stale P3 issues as inactive
         run: |
-          echo "🔍 Finding Priority:3 issues with fewest reactions and no activity in $INACTIVITY_DAYS+ days..."
+          echo "🔍 Finding Priority:3 issues with <5 upvotes and no activity in $INACTIVITY_DAYS+ days..."
           echo "📦 Batch size: $BATCH_SIZE"
           echo "🧪 Dry run: $DRY_RUN"
           echo "REPO: $REPO"
@@ -56,7 +56,7 @@ jobs:
           echo "⏰ Cutoff date: $CUTOFF_DATE"
           marked=0
 
-          echo "🔎 Searching for Priority:3 issues sorted by fewest reactions, last updated before $CUTOFF_DATE, without Status:Inactive"
+          echo "🔎 Searching for Priority:3 issues with <5 reactions, last updated before $CUTOFF_DATE, without Status:Inactive"
 
           issues=$(gh search issues \
             --repo "$REPO" \
@@ -67,6 +67,7 @@ jobs:
             is:open \
             label:Priority:3 \
             -label:Status:Inactive \
+            reactions:\<5 \
             updated:\<$CUTOFF_DATE \
             sort:reactions-asc)
 

--- a/.github/workflows/stale-p3-search.yml
+++ b/.github/workflows/stale-p3-search.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Mark stale P3 issues as inactive
         run: |
-          echo "🔍 Finding Priority:3 issues with no reactions and no activity in $INACTIVITY_DAYS+ days..."
+          echo "🔍 Finding Priority:3 issues with fewest reactions and no activity in $INACTIVITY_DAYS+ days..."
           echo "📦 Batch size: $BATCH_SIZE"
           echo "🧪 Dry run: $DRY_RUN"
           echo "REPO: $REPO"
@@ -56,7 +56,7 @@ jobs:
           echo "⏰ Cutoff date: $CUTOFF_DATE"
           marked=0
 
-          echo "🔎 Searching for Priority:3 issues with reactions:0, updated before $CUTOFF_DATE, without Status:Inactive"
+          echo "🔎 Searching for Priority:3 issues sorted by fewest reactions, last updated before $CUTOFF_DATE, without Status:Inactive"
 
           issues=$(gh search issues \
             --repo "$REPO" \
@@ -67,9 +67,8 @@ jobs:
             is:open \
             label:Priority:3 \
             -label:Status:Inactive \
-            reactions:0 \
             updated:\<$CUTOFF_DATE \
-            sort:updated-asc)
+            sort:reactions-asc)
 
           if [ -z "$issues" ]; then
             echo "✅ No eligible P3 issues found."


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/3674

- Replaces the 0 reaction constraint with **< 5 reactions**, bringing in any issues within a time range, sorted by their reaction count.
- Week-by-week, the lowest reaction p3's within the time range (2 years, currently) will be marked inactive.
- The process favors marking no-or-low upvoted issues over those with upvotes.

Validated with a Dry Run in https://github.com/NuGet/Home/actions/runs/25466485653/job/74720821668