### PR TITLE
Remove Experimental commment since the process is established

### DIFF
--- a/.github/policies/30-issue-stale-p3-cleanup.yml
+++ b/.github/policies/30-issue-stale-p3-cleanup.yml
@@ -29,8 +29,6 @@ configuration:
       - addReply:
           reply: >
             Due to lack of recent activity, this issue has been marked as a candidate for icebox cleanup. It will be closed if no further activity occurs within 14 more days. If the issue receives enough upvotes, it will be flagged with `Triage:NeedsTriageDiscussion` for team review.
-
-            This process is part of the experimental [Stale icebox issues cleanup](https://github.com/NuGet/Home/issues/12113) we are currently trialing. Please share any feedback you might have in the linked issue.
     - description: '[30-20] Close icebox cleanup candidates with no activity after 14 days'
       frequencies:
       - hourly:


### PR DESCRIPTION
We are adding a ton of cross-references on GitHub to every issue the bot closes.

Seems time to remove the experimental blurb and link from the bot's comments.